### PR TITLE
Make `client_secret` param optional

### DIFF
--- a/lib/ex_oauth2_provider/oauth2/token/utils.ex
+++ b/lib/ex_oauth2_provider/oauth2/token/utils.ex
@@ -7,7 +7,9 @@ defmodule ExOauth2Provider.Token.Utils do
   alias ExOauth2Provider.Utils.Error
 
   @doc false
-  def load_client(%{request: %{"client_id" => client_id, "client_secret" => client_secret}} = params) do
+  def load_client(%{request: request = %{"client_id" => client_id}} = params) do
+    client_secret = Map.get(request, "client_secret", "")
+
     case OauthApplications.get_application(client_id, client_secret) do
       nil    -> Error.add_error(params, Error.invalid_client())
       client -> Map.merge(params, %{client: client})


### PR DESCRIPTION
Resolves #16.

In short, `client_secret` should be an optional parameter since it can be omitted when no `client_secret` has been issued for the application.