### PR TITLE
Make UUID work and configurable app schema

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,3 +7,9 @@ sudo: false
 script:
   - mix test
   - mix credo
+
+  - MIX_ENV=test mix clean
+  - UUID=resource_owners mix test
+
+  - MIX_ENV=test mix clean
+  - UUID=all mix test

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://travis-ci.org/danschultzer/ex_oauth2_provider.svg?branch=master)](https://travis-ci.org/danschultzer/ex_oauth2_provider) [![hex.pm](http://img.shields.io/hexpm/v/ex_oauth2_provider.svg?style=flat)](https://hex.pm/packages/ex_oauth2_provider) [![hex.pm downloads](https://img.shields.io/hexpm/dt/ex_oauth2_provider.svg?style=flat)](https://hex.pm/packages/ex_oauth2_provider)
 
-The no brainer library to use for adding OAuth 2.0 provider capabilities to your Elixir app. You can use [phoenix_oauth2_provider](https://github.com/danschultzer/phoenix_oauth2_provider) for easy integration with your Phoenix app.
+The no-brainer library to use for adding OAuth 2.0 provider capabilities to your Elixir app. You can use [phoenix_oauth2_provider](https://github.com/danschultzer/phoenix_oauth2_provider) for easy integration with your Phoenix app.
 
 ## Installation
 
@@ -26,13 +26,13 @@ mix ex_oauth2_provider.install
 
 This will add the necessary Ecto migrations to your app, and set sample configuration in `config/config.exs`.
 
-You'll need to use a resource owner struct that already exists. This could be your User struct. If you don't have any User struct, you can add a migration like this:
+You are required to use a resource owner struct that already exists. This could be your `User` struct. If you don't have any `User` struct, you can create a migration with this:
 
 ```bash
 mix ecto.gen.migration --change "    create table(:users) do\n      add :email, :string\n    end"
 ```
 
-And use the struct in [test/support/dummy/models/user.ex](test/support/dummy/models/user.ex). The
+And use the struct in [test/support/dummy/models/user.ex](test/support/dummy/models/user.ex).
 
 If you're not using auto incremental integer (`:id`) for your primary key(s), please read the [Using UUID or custom primary key type](#using-uuid-or-custom-primary-key-type) section.
 
@@ -40,7 +40,7 @@ If you're not using auto incremental integer (`:id`) for your primary key(s), pl
 
 ### Authorization request
 
-You'll need to ensure that a resource_owner is already authenticated on these endpoints, and pass the struct as first argument in the following methods.
+You have to ensure that a `resource_owner` has been authenticated on the following endpoints, and pass the struct as the first argument in the following methods.
 
 ```elixir
 # GET /oauth/authorize?response_type=code&client_id=CLIENT_ID&redirect_uri=CALLBACK_URL&scope=read
@@ -110,7 +110,7 @@ config :ex_oauth2_provider, ExOauth2Provider,
   use_refresh_token: true
 ```
 
-The `refresh_token` grant flow will automatically be enabled.
+The `refresh_token` grant flow will then be enabled.
 
 ```elixir
 # POST /oauth/token?client_id=CLIENT_ID&client_secret=CLIENT_SECRET&grant_type=refresh_token&refresh_token=REFRESH_TOKEN
@@ -122,7 +122,7 @@ end
 
 #### Username and password
 
-You'll need to provide an authorization method that accepts username and password as arguments, and returns `{:ok, resource_owner}` or `{:error, reason}`. Something like this:
+You'll need to provide an authorization method that accepts username and password as arguments, and returns `{:ok, resource_owner}` or `{:error, reason}`. Here'a an example:
 
 ```elixir
 # Configuration in config/config.exs
@@ -142,7 +142,7 @@ defmodule MyApp.MyModule
 end
 ```
 
-The `password` grant flow will automatically be enabled.
+The `password` grant flow will then be enabled.
 
 ```elixir
 # POST /oauth/token?client_id=CLIENT_ID&grant_type=password&username=USERNAME&password=PASSWORD
@@ -166,15 +166,15 @@ config :ex_oauth2_provider, ExOauth2Provider,
 
 ## Plug API
 
-### ExOauth2Provider.Plug.VerifyHeader
+### [ExOauth2Provider.Plug.VerifyHeader](lib/ex_oauth2_provider/plug/verify_header.ex)
 
-Looks for a token in the Authorization Header. If one is not found, this does nothing.
+Looks for a token in the Authorization Header. If one is not found, this does nothing. This will always be necessary to run to load access token and resource owner.
 
-### ExOauth2Provider.Plug.EnsureAuthenticated
+### [ExOauth2Provider.Plug.EnsureAuthenticated](lib/ex_oauth2_provider/plug/ensure_authenticated.ex)
 
-Looks for a previously verified token. If one is found, continues, otherwise it will call the `:unauthenticated` function of your handler.
+Looks for a verified token loaded by [`VerifyHeader`](#exoauth2providerplugverifyheader). If one is not found it will call the `:unauthenticated` method in the `:handler` module.
 
-When you ensure a session, you can declare an error handler. This can be done as part of a pipeline or inside a Phoenix controller.
+You can use a custom `:handler` as part of a pipeline, or inside a Phoenix controller like so:
 
 ```elixir
 defmodule MyApp.MyController do
@@ -184,9 +184,11 @@ defmodule MyApp.MyController do
 end
 ```
 
-### ExOauth2Provider.Plug.EnsureScopes
+ The `:handler` module always defaults to [ExOauth2Provider.Plug.ErrorHandler](lib/ex_oauth2_provider/plug/error_handler.ex).
 
-Looks for a previously verified token. If one is found, confirms that all listed scopes are present in the token. If not, the `:unauthorized` function is called on your handler.
+### [ExOauth2Provider.Plug.EnsureScopes](lib/ex_oauth2_provider/plug/ensure_scopes.ex)
+
+Looks for a previously verified token. If one is found, confirms that all listed scopes are present in the token. If not, the `:unauthorized` function is called on your `:handler`.
 
 ```elixir
 defmodule MyApp.MyController do
@@ -207,25 +209,23 @@ defmodule MyApp.MyController do
 end
 ```
 
-### Current resource owner and token
+### Current resource owner and access token
 
-Access to the current resource owner and token is useful. You'll need to have run the VerifyHeader for token and resource access.
+If the Authorization Header was verified, you'll be able to retrieve the current resource owner or access token.
 
 ```elixir
 ExOauth2Provider.Plug.current_access_token(conn) # access the token in the default location
 ExOauth2Provider.Plug.current_access_token(conn, :secret) # access the token in the secret location
 ```
 
-For the resource
-
 ```elixir
-ExOauth2Provider.Plug.current_resource_owner(conn) # Access the loaded resource in the default location
-ExOauth2Provider.Plug.current_resource_owner(conn, :secret) # Access the loaded resource in the secret location
+ExOauth2Provider.Plug.current_resource_owner(conn) # Access the loaded resource owner in the default location
+ExOauth2Provider.Plug.current_resource_owner(conn, :secret) # Access the loaded resource owner in the secret location
 ```
 
 ### Custom access token generator
 
-You can add your own access token generator by doing the following:
+You can add your own access token generator, as this example shows:
 
 ```elixir
 # config/config.exs
@@ -279,7 +279,7 @@ mix ex_oauth2_provider.install --uuid resource_owners
 
 ### 2. If all structs should use `:uuid`
 
-If you don't have auto incrementing integer as primary keys in your database you can set up `ExOauth2Provider` to handle all primary keys as `:uuid` by doing the following.
+If you don't have auto-incrementing integers as primary keys in your database you can set up `ExOauth2Provider` to handle all primary keys as `:uuid` by doing the following.
 
 You should have a schema macro similar to this (the `@primary_key` and `@foreign_key_type` needs to be defined):
 
@@ -318,7 +318,7 @@ It's also possible to use a completely different setup by adding a custom schema
 
 This library was made thanks to [doorkeeper](https://github.com/doorkeeper-gem/doorkeeper), [guardian](https://github.com/ueberauth/guardian) and [authable](https://github.com/mustafaturan/authable), that gave the conceptual building blocks.
 
-Thanks to [Benjamin Schultzer](https://github.com/schultzer) for helping refactoring the code.
+Thanks to [Benjamin Schultzer](https://github.com/schultzer) for helping to refactor the code.
 
 ## LICENSE
 
@@ -329,4 +329,3 @@ Copyright (c) 2017 Dan Schultzer & the Contributors Permission is hereby granted
 The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 
 THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-0

--- a/README.md
+++ b/README.md
@@ -274,7 +274,19 @@ config :ex_oauth2_provider, ExOauth2Provider,
   app_schema: MyApp.Schema
 ```
 
-Remember to update the migration file, by default `ex_oauth_provider` will use integer fields for primary id's.
+You can create a UUID enabled migration file with the `--uuid` argument:
+
+```bash
+mix ex_oauth2_provider.install --uuid all
+```
+
+```bash
+mix ex_oauth2_provider.install --uuid resource_owners
+```
+
+```bash
+mix ex_oauth2_provider.install --uuid resource_owners,oauth_access_tokens
+```
 
 ## Acknowledgement
 

--- a/README.md
+++ b/README.md
@@ -265,6 +265,17 @@ end
 
 Remember to change the field type for the `token` column in the `oauth_access_tokens` table to accepts tokens larger than 255 characters.
 
+## UUID and custom primary key type
+
+You can set up `ExOauth2Provider` to use you custom schema attributes in case you're not using autoincrementing integer as primary keys in your database.
+
+```elixir
+config :ex_oauth2_provider, ExOauth2Provider,
+  app_schema: MyApp.Schema
+```
+
+Remember to update the migration file, by default `ex_oauth_provider` will use integer fields for primary id's.
+
 ## Acknowledgement
 
 This library was made thanks to [doorkeeper](https://github.com/doorkeeper-gem/doorkeeper), [guardian](https://github.com/ueberauth/guardian) and [authable](https://github.com/mustafaturan/authable), that gave the conceptual building blocks.

--- a/config/test.exs
+++ b/config/test.exs
@@ -10,6 +10,10 @@ config :ex_oauth2_provider, ExOauth2Provider,
   revoke_refresh_token_on_use: true,
   grant_flows: ~w(authorization_code client_credentials)
 
+if System.get_env("UUID") == "all" do
+  config :ex_oauth2_provider, ExOauth2Provider, app_schema: Dummy.UUIDSchema
+end
+
 config :ex_oauth2_provider, ecto_repos: [ExOauth2Provider.Test.Repo]
 
 config :ex_oauth2_provider, ExOauth2Provider.Test.Repo,

--- a/lib/ex_oauth2_provider/config.ex
+++ b/lib/ex_oauth2_provider/config.ex
@@ -12,6 +12,12 @@ defmodule ExOauth2Provider.Config do
   end
 
   @doc false
+  @spec app_schema() :: atom
+  def app_schema do
+    Keyword.get(config(), :app_schema, Ecto.Schema)
+  end
+
+  @doc false
   @spec application_owner_struct() :: atom
   def application_owner_struct do
     Keyword.get(config(), :application_owner, resource_owner_struct())

--- a/lib/ex_oauth2_provider/oauth_access_grants/oauth_access_grant.ex
+++ b/lib/ex_oauth2_provider/oauth_access_grants/oauth_access_grant.ex
@@ -5,7 +5,7 @@ defmodule ExOauth2Provider.OauthAccessGrants.OauthAccessGrant do
   alias ExOauth2Provider.OauthApplications.OauthApplication
 
   schema "oauth_access_grants" do
-    belongs_to :resource_owner, ExOauth2Provider.Config.resource_owner_struct
+    belongs_to :resource_owner, ExOauth2Provider.Config.resource_owner_struct(), type: ExOauth2Provider.Config.resource_owner_struct().__schema__(:type, :id)
     belongs_to :application, OauthApplication
 
     field :token,        :string,     null: false

--- a/lib/ex_oauth2_provider/oauth_access_grants/oauth_access_grant.ex
+++ b/lib/ex_oauth2_provider/oauth_access_grants/oauth_access_grant.ex
@@ -1,7 +1,7 @@
 defmodule ExOauth2Provider.OauthAccessGrants.OauthAccessGrant do
   @moduledoc false
 
-  use Ecto.Schema
+  use ExOauth2Provider.Schema
   alias ExOauth2Provider.OauthApplications.OauthApplication
 
   schema "oauth_access_grants" do

--- a/lib/ex_oauth2_provider/oauth_access_tokens/oauth_access_token.ex
+++ b/lib/ex_oauth2_provider/oauth_access_tokens/oauth_access_token.ex
@@ -1,7 +1,7 @@
 defmodule ExOauth2Provider.OauthAccessTokens.OauthAccessToken do
   @moduledoc false
 
-  use Ecto.Schema
+  use ExOauth2Provider.Schema
   alias ExOauth2Provider.OauthApplications.OauthApplication
 
   schema "oauth_access_tokens" do

--- a/lib/ex_oauth2_provider/oauth_access_tokens/oauth_access_token.ex
+++ b/lib/ex_oauth2_provider/oauth_access_tokens/oauth_access_token.ex
@@ -6,7 +6,7 @@ defmodule ExOauth2Provider.OauthAccessTokens.OauthAccessToken do
 
   schema "oauth_access_tokens" do
     belongs_to :application, OauthApplication, on_replace: :nilify
-    belongs_to :resource_owner, ExOauth2Provider.Config.resource_owner_struct
+    belongs_to :resource_owner, ExOauth2Provider.Config.resource_owner_struct(), type: ExOauth2Provider.Config.resource_owner_struct().__schema__(:type, :id)
 
     field :token,         :string, null: false
     field :refresh_token, :string

--- a/lib/ex_oauth2_provider/oauth_applications/oauth_application.ex
+++ b/lib/ex_oauth2_provider/oauth_applications/oauth_application.ex
@@ -1,7 +1,7 @@
 defmodule ExOauth2Provider.OauthApplications.OauthApplication do
   @moduledoc false
 
-  use Ecto.Schema
+  use ExOauth2Provider.Schema
   require Logger
 
   # For Phoenix integrations

--- a/lib/ex_oauth2_provider/oauth_applications/oauth_application.ex
+++ b/lib/ex_oauth2_provider/oauth_applications/oauth_application.ex
@@ -14,7 +14,7 @@ defmodule ExOauth2Provider.OauthApplications.OauthApplication do
       Logger.error("You need to set a resource_owner or application_owner in your config and recompile ex_oauth2_provider!")
     end
 
-    belongs_to :owner, ExOauth2Provider.Config.application_owner_struct()
+    belongs_to :owner, ExOauth2Provider.Config.application_owner_struct(), type: ExOauth2Provider.Config.resource_owner_struct().__schema__(:type, :id)
 
     field :name,         :string,     null: false
     field :uid,          :string,     null: false

--- a/lib/ex_oauth2_provider/schema.ex
+++ b/lib/ex_oauth2_provider/schema.ex
@@ -1,0 +1,10 @@
+defmodule ExOauth2Provider.Schema do
+  @moduledoc """
+  This module will permit dynamic App.Schema load.
+  """
+  defmacro __using__(_) do
+    quote do
+      use unquote(ExOauth2Provider.Config.app_schema())
+    end
+  end
+end

--- a/priv/templates/migrations/create_oauth_tables.exs
+++ b/priv/templates/migrations/create_oauth_tables.exs
@@ -2,8 +2,10 @@ defmodule <%= inspect mod %> do
   use Ecto.Migration
 
   def change do
-    create table(:oauth_applications) do
-      add :owner_id,          :integer, null: false
+    create table(:oauth_applications<%= if uuid[:oauth_applications], do: ", primary_key: false" %>) do<%= if uuid[:oauth_applications] do %>
+      add :id,                :uuid,    primary_key: true<% end %><%= if uuid[:resource_owners] do %>
+      add :owner_id,          :uuid,    null: false<% else %>
+      add :owner_id,          :integer, null: false<% end %>
       add :name,              :string,  null: false
       add :uid,               :string,  null: false
       add :secret,            :string,  null: false
@@ -16,9 +18,11 @@ defmodule <%= inspect mod %> do
     create unique_index(:oauth_applications, [:uid])
     create index(:oauth_applications, [:owner_id])
 
-    create table(:oauth_access_grants) do
-      add :resource_owner_id,      :integer,        null: false
-      add :application_id,         references(:oauth_applications)
+    create table(:oauth_access_grants<%= if uuid[:oauth_access_grants], do: ", primary_key: false" %>) do<%= if uuid[:oauth_access_grants] do %>
+      add :id,                     :uuid,           primary_key: true<% end %><%= if uuid[:resource_owners] do %>
+      add :resource_owner_id,      :uuid,           null: false<% else %>
+      add :resource_owner_id,      :integer,        null: false<% end %>
+      add :application_id,         references(:oauth_applications<%= if uuid[:oauth_applications], do: ", type: :uuid" %>)
       add :token,                  :string,         null: false
       add :expires_in,             :integer,        null: false
       add :redirect_uri,           :string,         null: false
@@ -30,9 +34,11 @@ defmodule <%= inspect mod %> do
 
     create unique_index(:oauth_access_grants, [:token])
 
-    create table(:oauth_access_tokens) do
-      add :application_id,         references(:oauth_applications)
-      add :resource_owner_id,      :integer
+    create table(:oauth_access_tokens<%= if uuid[:oauth_access_tokens], do: ", primary_key: false" %>) do<%= if uuid[:oauth_access_tokens] do %>
+      add :id,                     :uuid, primary_key: true<% end %>
+      add :application_id,         references(:oauth_applications<%= if uuid[:oauth_applications], do: ", type: :uuid" %>)<%= if uuid[:resource_owners] do %>
+      add :resource_owner_id,      :uuid<% else %>
+      add :resource_owner_id,      :integer<% end %>
 
       # If you use a custom token generator you may need to change this column
       # from string to text, so that it accepts tokens larger than 255

--- a/priv/test/migrations/20170320052040_create_user.exs
+++ b/priv/test/migrations/20170320052040_create_user.exs
@@ -2,7 +2,10 @@ defmodule ExOauth2Provider.Test.Repo.Migrations.CreateUser do
   use Ecto.Migration
 
   def change do
-    create table(:users) do
+    create table(:users, primary_key: is_nil(System.get_env("UUID"))) do
+      if System.get_env("UUID") do
+        add :id, :uuid, primary_key: true
+      end
       add :email, :string
       timestamps()
     end

--- a/test/ex_oauth2_provider/oauth_access_tokens/oauth_access_tokens_test.exs
+++ b/test/ex_oauth2_provider/oauth_access_tokens/oauth_access_tokens_test.exs
@@ -230,7 +230,8 @@ defmodule ExOauth2Provider.OauthAccessTokensTest do
     {:ok, token2} = OauthAccessTokens.get_or_create_token(fixture(:user))
     assert token.id != token2.id
 
-    Enum.each(%{application_id: 0,
+    application_id = (if System.get_env("UUID") == "all", do: "09b58e2b-8fff-4b8d-ba94-18a06dd4fc29", else: 0)
+    Enum.each(%{application_id: application_id,
                 expires_in: 0,
                 scopes: nil}, fn({k, v}) ->
       {:ok, token2} = OauthAccessTokens.get_or_create_token(user, %{"#{k}": v})

--- a/test/ex_oauth2_provider_test.exs
+++ b/test/ex_oauth2_provider_test.exs
@@ -66,8 +66,10 @@ defmodule ExOauth2ProviderTest do
   end
 
   test "authenticate_token/1 error when no resource owner" do
+    resource_owner_id = (if is_nil(System.get_env("UUID")), do: 0, else: "09b58e2b-8fff-4b8d-ba94-18a06dd4fc29")
+
     access_token = fixture(:access_token, fixture(:user), %{})
-    |> Ecto.Changeset.change(resource_owner_id: 0)
+    |> Ecto.Changeset.change(resource_owner_id: resource_owner_id)
     |> ExOauth2Provider.repo.update!
 
     assert authenticate_token(access_token.token) == {:error, :no_association_found}

--- a/test/mix/tasks/ex_oauth2_provider.install_test.exs
+++ b/test/mix/tasks/ex_oauth2_provider.install_test.exs
@@ -38,6 +38,53 @@ defmodule Mix.Tasks.ExOauth2Provider.InstallTest do
       assert file =~ "defmodule Mix.Tasks.ExOauth2Provider.InstallTest.Repo.Migrations.CreateOauthTables do"
       assert file =~ "use Ecto.Migration"
       assert file =~ "def change do"
+      assert file =~ "add :owner_id,          :integer, null: false"
+      assert file =~ "add :resource_owner_id,      :integer"
+      refute file =~ "add :owner_id,          :uuid,    null: false"
+      refute file =~ "add :resource_owner_id,      :uuid"
+      refute file =~ ":oauth_applications, primary_key: false"
+      refute file =~ ":oauth_access_grants, primary_key: false"
+      refute file =~ ":oauth_access_tokens, primary_key: false"
+      refute file =~ "add :id,                     :uuid,           primary_key: true"
+      refute file =~ "add :id,                :uuid,    primary_key: true"
+      refute file =~ "add :id,                     :uuid,           primary_key: true"
+      refute file =~ "add :application_id,         references(:oauth_applications, type: :uuid)"
+    end
+  end
+
+  test "generates migrations with uuid for resource_owners" do
+    run @options ++ ~w(--uuid resource_owners)
+    assert [name] = File.ls!(@migrations_path)
+    assert_file Path.join(@migrations_path, name), fn file ->
+      refute file =~ "add :owner_id,          :integer, null: false"
+      refute file =~ "add :resource_owner_id,      :integer"
+      assert file =~ "add :owner_id,          :uuid,    null: false"
+      assert file =~ "add :resource_owner_id,      :uuid"
+      refute file =~ ":oauth_applications, primary_key: false"
+      refute file =~ ":oauth_access_grants, primary_key: false"
+      refute file =~ ":oauth_access_tokens, primary_key: false"
+      refute file =~ "add :id,                     :uuid,           primary_key: true"
+      refute file =~ "add :id,                :uuid,    primary_key: true"
+      refute file =~ "add :id,                     :uuid,           primary_key: true"
+      refute file =~ "add :application_id,         references(:oauth_applications, type: :uuid)"
+    end
+  end
+
+  test "generates migrations with uuid for all" do
+    run @options ++ ~w(--uuid all)
+    assert [name] = File.ls!(@migrations_path)
+    assert_file Path.join(@migrations_path, name), fn file ->
+      refute file =~ "add :owner_id,          :integer, null: false"
+      refute file =~ "add :resource_owner_id,      :integer"
+      assert file =~ "add :owner_id,          :uuid,    null: false"
+      assert file =~ "add :resource_owner_id,      :uuid"
+      assert file =~ ":oauth_applications, primary_key: false"
+      assert file =~ ":oauth_access_grants, primary_key: false"
+      assert file =~ ":oauth_access_tokens, primary_key: false"
+      assert file =~ "add :id,                     :uuid,           primary_key: true"
+      assert file =~ "add :id,                :uuid,    primary_key: true"
+      assert file =~ "add :id,                     :uuid,           primary_key: true"
+      assert file =~ "add :application_id,         references(:oauth_applications, type: :uuid)"
     end
   end
 

--- a/test/support/dummy/models/user.ex
+++ b/test/support/dummy/models/user.ex
@@ -1,7 +1,7 @@
 defmodule Dummy.User do
   @moduledoc false
 
-  use Ecto.Schema
+  use Dummy.UUIDSchema
   import Ecto.Changeset
 
   schema "users" do

--- a/test/support/dummy/uuid_schema.ex
+++ b/test/support/dummy/uuid_schema.ex
@@ -1,0 +1,12 @@
+defmodule Dummy.UUIDSchema do
+  @moduledoc false
+  defmacro __using__(_) do
+    quote do
+      use Ecto.Schema
+      unless is_nil(System.get_env("UUID")) do
+        @primary_key {:id, :binary_id, autogenerate: true}
+        @foreign_key_type :binary_id
+      end
+    end
+  end
+end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,8 +1,12 @@
 alias ExOauth2Provider.Test.Repo
 
+additional_opts = if System.get_env("UUID"), do: ["--uuid", System.get_env("UUID")], else: []
+install_opts = Enum.concat(["--no-config"], additional_opts)
+
 # Setting up the database with dummy user model
 Mix.Task.run "ecto.drop", ~w(--quiet)
-Mix.Task.run "ex_oauth2_provider.install", ~w(--no-config)
+Mix.shell.cmd("rm priv/test/migrations/*_create_oauth_tables.exs")
+Mix.Task.run "ex_oauth2_provider.install", install_opts
 Mix.Task.run "ecto.create", ~w(--quiet)
 Mix.Task.run "ecto.migrate"
 


### PR DESCRIPTION
This is a proposed fix to #20.

Now UUID can be used for the resource owner. UUID enabled migration file can be created with:

```bash
mix ex_oauth2_provider.install --uuid resource_owners
```

Furthermore, you to set a custom schema module for all structs in case your database doesn't support auto incremental integers:

```elixir
config :ex_oauth2_provider, ExOauth2Provider,
  app_schema: MyApp.Schema
```

And to create a migration file with UUID enabled for all tables:

```bash
mix ex_oauth2_provider.install --uuid all
```