### PR TITLE
Permit secret to be empty string

### DIFF
--- a/lib/ex_oauth2_provider/oauth_applications/oauth_applications.ex
+++ b/lib/ex_oauth2_provider/oauth_applications/oauth_applications.ex
@@ -218,10 +218,18 @@ defmodule ExOauth2Provider.OauthApplications do
   defp application_changeset(%OauthApplication{} = application, params) do
     application
     |> cast(params, [:name, :secret, :redirect_uri, :scopes])
-    |> validate_required([:name, :uid, :secret, :redirect_uri])
+    |> validate_required([:name, :uid, :redirect_uri])
+    |> validate_secret_not_nil()
     |> validate_scopes()
     |> validate_redirect_uri()
     |> unique_constraint(:uid)
+  end
+
+  defp validate_secret_not_nil(changeset) do
+    case get_field(changeset, :secret) do
+      nil -> add_error(changeset, :secret, "can't be blank")
+      _ -> changeset
+    end
   end
 
   defp new_application_changeset(%OauthApplication{} = application, owner, params) do

--- a/test/ex_oauth2_provider/oauth_applications/oauth_applications_test.exs
+++ b/test/ex_oauth2_provider/oauth_applications/oauth_applications_test.exs
@@ -126,9 +126,13 @@ defmodule ExOauth2Provider.OauthApplicationsTest do
   end
 
   test "change_application/1 validates secret" do
+    application = %OauthApplication{secret: nil}
+    changeset = OauthApplications.change_application(application)
+    assert changeset.errors[:secret] == {"can't be blank", []}
+
     application = %OauthApplication{secret: ""}
     changeset = OauthApplications.change_application(application)
-    assert changeset.errors[:secret]
+    assert is_nil(changeset.errors[:secret])
   end
 
   test "change_application/1 requires valid redirect uri" do


### PR DESCRIPTION
Resolves #26 

As per #16, applications can be created with no `client_secret` set. Now, `application_changeset/2` only validates that `secret` is not nil.