### PR TITLE
Bug fix empty string application secret

### DIFF
--- a/lib/ex_oauth2_provider/oauth_applications/oauth_application.ex
+++ b/lib/ex_oauth2_provider/oauth_applications/oauth_application.ex
@@ -17,7 +17,7 @@ defmodule ExOauth2Provider.OauthApplications.OauthApplication do
 
     field :name,         :string,     null: false
     field :uid,          :string,     null: false
-    field :secret,       :string,     null: false
+    field :secret,       :string,     null: false, default: ""
     field :redirect_uri, :string,     null: false
     field :scopes,       :string,     null: false, default: ""
 

--- a/test/ex_oauth2_provider/oauth_applications/oauth_applications_test.exs
+++ b/test/ex_oauth2_provider/oauth_applications/oauth_applications_test.exs
@@ -83,6 +83,12 @@ defmodule ExOauth2Provider.OauthApplicationsTest do
     assert application.secret != application2.secret
   end
 
+  test "create_application/2 permits empty string secret", %{user: user} do
+    attrs = Map.merge(@valid_attrs, %{secret: ""})
+    assert {:ok, application} = OauthApplications.create_application(user, attrs)
+    assert application.secret == ""
+  end
+
   test "create_application/2 adds random uid", %{user: user} do
     {:ok, application} = OauthApplications.create_application(user, @valid_attrs)
     {:ok, application2} = OauthApplications.create_application(user, @valid_attrs)


### PR DESCRIPTION
Resolves #28 

Empty strings [are pruned by Ecto](https://github.com/elixir-ecto/ecto/issues/1684). So #27 didn't actually resolve #26.

The simplest fix was just to set the `default` value in the Ecto column definition, and test creation with an empty string secret.