### PR TITLE
Check for access token expiration

### DIFF
--- a/lib/ex_oauth2_provider/oauth_access_tokens/oauth_access_tokens.ex
+++ b/lib/ex_oauth2_provider/oauth_access_tokens/oauth_access_tokens.ex
@@ -105,16 +105,23 @@ defmodule ExOauth2Provider.OauthAccessTokens do
     end
   end
 
+  @spec get_active_tokens_for(Ecto.Schema.t) :: [%OauthAccessToken{}]
+  @since "0.3.3"
+  @deprecated "Use get_authorized_tokens_for/2 instead"
+  def get_active_tokens_for(resource_owner) do
+    get_authorized_tokens_for(resource_owner)
+  end
+
   @doc """
-  Gets all active tokens for resource owner.
+  Gets all authorized access tokens for resource owner.
 
   ## Examples
 
-      iex> get_active_tokens_for(resource_owner)
+      iex> get_authorized_tokens_for(resource_owner)
       [%OauthAccessToken{}, ...]
   """
-  @spec get_active_tokens_for(Ecto.Schema.t) :: [%OauthAccessToken{}]
-  def get_active_tokens_for(resource_owner) do
+  @spec get_authorized_tokens_for(Ecto.Schema.t) :: [%OauthAccessToken{}]
+  def get_authorized_tokens_for(resource_owner) do
     resource_owner_clause = ExOauth2Provider.Utils.belongs_to_clause(OauthAccessToken, :resource_owner, resource_owner)
 
     OauthAccessToken

--- a/lib/ex_oauth2_provider/oauth_access_tokens/oauth_access_tokens.ex
+++ b/lib/ex_oauth2_provider/oauth_access_tokens/oauth_access_tokens.ex
@@ -121,7 +121,6 @@ defmodule ExOauth2Provider.OauthAccessTokens do
     |> where(^resource_owner_clause)
     |> where([o], is_nil(o.revoked_at))
     |> ExOauth2Provider.repo.all()
-    |> Enum.reject(&is_expired?/1)
   end
 
   @doc """

--- a/lib/ex_oauth2_provider/oauth_applications/oauth_applications.ex
+++ b/lib/ex_oauth2_provider/oauth_applications/oauth_applications.ex
@@ -116,7 +116,7 @@ defmodule ExOauth2Provider.OauthApplications do
     %{owner_key: owner_key, related_key: related_key} = ExOauth2Provider.Utils.schema_association(OauthAccessTokens.OauthAccessToken, :application)
 
     application_ids = resource_owner
-                      |> OauthAccessTokens.get_active_tokens_for()
+                      |> OauthAccessTokens.get_authorized_tokens_for()
                       |> Enum.map(&Map.get(&1, owner_key))
 
     OauthApplication

--- a/test/ex_oauth2_provider/oauth_access_tokens/oauth_access_tokens_test.exs
+++ b/test/ex_oauth2_provider/oauth_access_tokens/oauth_access_tokens_test.exs
@@ -90,13 +90,15 @@ defmodule ExOauth2Provider.OauthAccessTokensTest do
     {:ok, token} = OauthAccessTokens.create_token(user, %{application: application})
     assert [%OauthAccessToken{}] = OauthAccessTokens.get_active_tokens_for(user)
 
+    token
+    |> Ecto.Changeset.change(expires_in: -1)
+    |> ExOauth2Provider.repo().update()
+    assert [%OauthAccessToken{}] = OauthAccessTokens.get_active_tokens_for(user)
+
     OauthAccessTokens.revoke(token)
     assert [] = OauthAccessTokens.get_active_tokens_for(user)
 
     assert [] == OauthAccessTokens.get_active_tokens_for(fixture(:user))
-
-    {:ok, _} = OauthAccessTokens.create_token(user, %{application: application, expires_in: -1})
-    assert OauthAccessTokens.get_active_tokens_for(user) == []
   end
 
   test "create_token/2 with valid attributes", %{user: user} do

--- a/test/ex_oauth2_provider/oauth_access_tokens/oauth_access_tokens_test.exs
+++ b/test/ex_oauth2_provider/oauth_access_tokens/oauth_access_tokens_test.exs
@@ -78,6 +78,12 @@ defmodule ExOauth2Provider.OauthAccessTokensTest do
 
     refute OauthAccessTokens.get_matching_token_for(user, application, "other_read")
     refute OauthAccessTokens.get_matching_token_for(fixture(:user), application, nil)
+
+    token1
+    |> Ecto.Changeset.change(expires_in: -1)
+    |> ExOauth2Provider.repo().update
+
+    refute OauthAccessTokens.get_matching_token_for(user, application, "write read")
   end
 
   test "get_active_tokens_for/1", %{user: user, application: application} do
@@ -88,6 +94,9 @@ defmodule ExOauth2Provider.OauthAccessTokensTest do
     assert [] = OauthAccessTokens.get_active_tokens_for(user)
 
     assert [] == OauthAccessTokens.get_active_tokens_for(fixture(:user))
+
+    {:ok, _} = OauthAccessTokens.create_token(user, %{application: application, expires_in: -1})
+    assert OauthAccessTokens.get_active_tokens_for(user) == []
   end
 
   test "create_token/2 with valid attributes", %{user: user} do

--- a/test/ex_oauth2_provider/oauth_access_tokens/oauth_access_tokens_test.exs
+++ b/test/ex_oauth2_provider/oauth_access_tokens/oauth_access_tokens_test.exs
@@ -86,19 +86,19 @@ defmodule ExOauth2Provider.OauthAccessTokensTest do
     refute OauthAccessTokens.get_matching_token_for(user, application, "write read")
   end
 
-  test "get_active_tokens_for/1", %{user: user, application: application} do
+  test "get_authorized_tokens_for/1", %{user: user, application: application} do
     {:ok, token} = OauthAccessTokens.create_token(user, %{application: application})
-    assert [%OauthAccessToken{}] = OauthAccessTokens.get_active_tokens_for(user)
+    assert [%OauthAccessToken{}] = OauthAccessTokens.get_authorized_tokens_for(user)
 
     token
     |> Ecto.Changeset.change(expires_in: -1)
     |> ExOauth2Provider.repo().update()
-    assert [%OauthAccessToken{}] = OauthAccessTokens.get_active_tokens_for(user)
+    assert [%OauthAccessToken{}] = OauthAccessTokens.get_authorized_tokens_for(user)
 
     OauthAccessTokens.revoke(token)
-    assert [] = OauthAccessTokens.get_active_tokens_for(user)
+    assert [] = OauthAccessTokens.get_authorized_tokens_for(user)
 
-    assert [] == OauthAccessTokens.get_active_tokens_for(fixture(:user))
+    assert [] == OauthAccessTokens.get_authorized_tokens_for(fixture(:user))
   end
 
   test "create_token/2 with valid attributes", %{user: user} do


### PR DESCRIPTION
`ExOauth2Provider.OauthAccessTokens.get_matching_token_for/3` doesn't check access tokens for expiration. In phoenix_oauth2_provider it makes the authorization endpoint return an expired token if there's one in the database.