### PR TITLE
Fix matching token bug

### DIFF
--- a/lib/ex_oauth2_provider/oauth_access_tokens/oauth_access_tokens.ex
+++ b/lib/ex_oauth2_provider/oauth_access_tokens/oauth_access_tokens.ex
@@ -86,11 +86,13 @@ defmodule ExOauth2Provider.OauthAccessTokens do
     |> where(^resource_owner_clause)
     |> where([x], is_nil(x.revoked_at))
     |> order_by([x], desc: x.inserted_at)
-    |> limit(1)
-    |> ExOauth2Provider.repo.one()
+    |> ExOauth2Provider.repo.all()
     |> check_matching_scopes(scopes)
   end
 
+  defp check_matching_scopes(tokens, scopes) when is_list(tokens) do
+    Enum.find(tokens, nil, &check_matching_scopes(&1, scopes))
+  end
   defp check_matching_scopes(nil, _), do: nil
   defp check_matching_scopes(token, scopes) do
     token_scopes   = Scopes.to_list(token.scopes)

--- a/test/ex_oauth2_provider/oauth_access_tokens/oauth_access_tokens_test.exs
+++ b/test/ex_oauth2_provider/oauth_access_tokens/oauth_access_tokens_test.exs
@@ -61,7 +61,7 @@ defmodule ExOauth2Provider.OauthAccessTokensTest do
     assert %OauthAccessToken{id: id} = OauthAccessTokens.get_matching_token_for(user, application, "public")
     assert token2.id == id
 
-    inserted_at = NaiveDateTime.utc_now |> NaiveDateTime.add(1, :second)
+    inserted_at = NaiveDateTime.add(NaiveDateTime.utc_now(), 1, :second)
     token1
     |> Ecto.Changeset.change(inserted_at: inserted_at)
     |> ExOauth2Provider.repo.update
@@ -73,9 +73,11 @@ defmodule ExOauth2Provider.OauthAccessTokensTest do
     |> ExOauth2Provider.repo.update
     assert %OauthAccessToken{id: id} = OauthAccessTokens.get_matching_token_for(user, application, "write read")
     assert id == token1.id
+    assert %OauthAccessToken{id: id} = OauthAccessTokens.get_matching_token_for(user, application, "public")
+    assert id == token2.id
 
-    assert nil == OauthAccessTokens.get_matching_token_for(user, application, "other_read")
-    assert nil == OauthAccessTokens.get_matching_token_for(fixture(:user), application, nil)
+    refute OauthAccessTokens.get_matching_token_for(user, application, "other_read")
+    refute OauthAccessTokens.get_matching_token_for(fixture(:user), application, nil)
   end
 
   test "get_active_tokens_for/1", %{user: user, application: application} do


### PR DESCRIPTION
`get_matching_token_for/1` was not working correctly. With this fix it'll now load the most recent active access token based on the scope.