### PR TITLE
Update readme and add test for no client secret

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,10 @@ end
 
 Revocation will return `{:ok, %{}}` status even if the token is invalid.
 
+### Authorization code flow in a Single Page Application
+
+`ex_oauth2_provider` doesn't support **implicit** grant flow. Instead you should set up an application with no client secret, and use the **Authorize code** grant flow. `ex_oauth2_provider` won't require a `client_secret` unless it has been set for the application.
+
 ### Other supported token grants
 
 #### Client credentials

--- a/test/ex_oauth2_provider/oauth2/token/strategy/authorization_code_test.exs
+++ b/test/ex_oauth2_provider/oauth2/token/strategy/authorization_code_test.exs
@@ -46,6 +46,15 @@ defmodule ExOauth2Provider.Token.Strategy.AuthorizationCodeTest do
     refute is_nil(get_last_access_token().refresh_token)
   end
 
+  test "#grant/1 returns access token when client secret not required", %{resource_owner: resource_owner, application: application} do
+    application |> Ecto.Changeset.change(secret: "") |> ExOauth2Provider.repo.update!()
+    valid_request_no_client_secret = Map.drop(@valid_request, ["client_secret"])
+
+    assert {:ok, access_token} = grant(valid_request_no_client_secret)
+    assert get_last_access_token().resource_owner_id == resource_owner.id
+    assert get_last_access_token().application_id == application.id
+  end
+
   def access_token_response_body_handler(body, access_token) do
     body
     |> Map.merge(%{custom_attr: access_token.inserted_at})


### PR DESCRIPTION
Update the readme to describe how SPA can use the authorization code flow instead of implicit grant type.

Derived from discussion in #31 