### PR TITLE
Ensure application wide access tokens can be authenticated

### DIFF
--- a/lib/ex_oauth2_provider.ex
+++ b/lib/ex_oauth2_provider.ex
@@ -75,9 +75,9 @@ defmodule ExOauth2Provider do
   defp load_resource({:ok, access_token}) do
     access_token = repo().preload(access_token, :resource_owner)
 
-    case access_token.resource_owner do
-      nil -> {:error, :no_association_found}
-      _   -> {:ok, access_token}
+    case is_nil(access_token.resource_owner_id) || not is_nil(access_token.resource_owner) do
+      true  -> {:ok, access_token}
+      false -> {:error, :no_association_found}
     end
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -39,7 +39,7 @@ defmodule ExOauth2Provider.Mixfile do
 
   defp deps do
     [{:ecto, ">= 2.1.0 or < 2.3.0"},
-     {:plug, ">= 1.0.0 and < 1.7.0"},
+     {:plug, ">= 1.0.0 and < 1.8.0"},
      {:jason, "~> 1.1"},
      {:postgrex, ">= 0.11.1", optional: true},
 


### PR DESCRIPTION
Resolves #40 

I'll have to check up on this to ensure this is the proper way of handling the access token.

https://tools.ietf.org/html/rfc6749#section-1.3.4