### PR TITLE
Use :otp_app in passed config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v0.5.1 (TBA)
 
 * Relaxed plug requirement up to 2.0.0
+* Fix bug where otp app name could not be fetched in release
 
 ## v0.5.0 (2019-05-08)
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ You have to ensure that a `resource_owner` has been authenticated on the followi
 
 ```elixir
 # GET /oauth/authorize?response_type=code&client_id=CLIENT_ID&redirect_uri=CALLBACK_URL&scope=read
-case ExOauth2Provider.Authorization.preauthorize(resource_owner, params, config) do
+case ExOauth2Provider.Authorization.preauthorize(resource_owner, params, otp_app: :my_app) do
   {:ok, client, scopes}             -> # render authorization page
   {:redirect, redirect_uri}         -> # redirect to external redirect_uri
   {:native_redirect, %{code: code}} -> # redirect to local :show endpoint
@@ -54,14 +54,14 @@ case ExOauth2Provider.Authorization.preauthorize(resource_owner, params, config)
 end
 
 # POST /oauth/authorize?response_type=code&client_id=CLIENT_ID&redirect_uri=CALLBACK_URL&scope=read
-ExOauth2Provider.Authorization.authorize(resource_owner, params, config) do
+ExOauth2Provider.Authorization.authorize(resource_owner, params, otp_app: :my_app) do
   {:redirect, redirect_uri}         -> # redirect to external redirect_uri
   {:native_redirect, %{code: code}} -> # redirect to local :show endpoint
   {:error, error, http_status}      -> # render error page
 end
 
 # DELETE /oauth/authorize?response_type=code&client_id=CLIENT_ID&redirect_uri=CALLBACK_URL&scope=read
-ExOauth2Provider.Authorization.deny(resource_owner, params, config) do
+ExOauth2Provider.Authorization.deny(resource_owner, params, otp_app: :my_app) do
   {:redirect, redirect_uri}         -> # redirect to external redirect_uri
   {:error, error, http_status}      -> # render error page
 end
@@ -71,7 +71,7 @@ end
 
 ```elixir
 # POST /oauth/token?client_id=CLIENT_ID&client_secret=CLIENT_SECRET&grant_type=authorization_code&code=AUTHORIZATION_CODE&redirect_uri=CALLBACK_URL
-case ExOauth2Provider.Token.grant(params, config) do
+case ExOauth2Provider.Token.grant(params, otp_app: :my_app) do
   {:ok, access_token}               -> # JSON response
   {:error, error, http_status}      -> # JSON response
 end
@@ -81,7 +81,7 @@ end
 
 ```elixir
 # GET /oauth/revoke?client_id=CLIENT_ID&client_secret=CLIENT_SECRET&token=ACCESS_TOKEN
-case ExOauth2Provider.Token.revoke(params, config) do
+case ExOauth2Provider.Token.revoke(params, otp_app: :my_app) do
   {:ok, %{}}                        -> # JSON response
   {:error, error, http_status}      -> # JSON response
 end
@@ -99,7 +99,7 @@ ExOauth2Provider doesn't support **implicit** grant flow. Instead you should set
 
 ```elixir
 # POST /oauth/token?client_id=CLIENT_ID&client_secret=CLIENT_SECRET&grant_type=client_credentials
-case ExOauth2Provider.Token.grant(params, config) do
+case ExOauth2Provider.Token.grant(params, otp_app: :my_app) do
   {:ok, access_token}               -> # JSON response
   {:error, error, http_status}      -> # JSON response
 end
@@ -120,7 +120,7 @@ The `refresh_token` grant flow will then be enabled.
 
 ```elixir
 # POST /oauth/token?client_id=CLIENT_ID&client_secret=CLIENT_SECRET&grant_type=refresh_token&refresh_token=REFRESH_TOKEN
-case ExOauth2Provider.Token.grant(params, config) do
+case ExOauth2Provider.Token.grant(params, otp_app: :my_app) do
   {:ok, access_token}               -> # JSON response
   {:error, error, http_status}      -> # JSON response
 end
@@ -137,7 +137,7 @@ config :my_app, ExOauth2Provider,
 
 # Module example
 defmodule Auth do
-  def authenticate(username, password, config) do
+  def authenticate(username, password, otp_app: :my_app) do
     user = Repo.get_by(User, email: username)
 
     cond do
@@ -153,7 +153,7 @@ The `password` grant flow will then be enabled.
 
 ```elixir
 # POST /oauth/token?client_id=CLIENT_ID&grant_type=password&username=USERNAME&password=PASSWORD
-case ExOauth2Provider.Token.grant(params, config) do
+case ExOauth2Provider.Token.grant(params, otp_app: :my_app) do
   {:ok, access_token}               -> # JSON response
   {:error, error, http_status}      -> # JSON response
 end
@@ -224,7 +224,7 @@ end
 If the Authorization Header was verified, you'll be able to retrieve the current resource owner or access token.
 
 ```elixir
-ExOauth2Provider.Plug.current_access_token(conn, config) # access the token in the default location
+ExOauth2Provider.Plug.current_access_token(conn) # access the token in the default location
 ExOauth2Provider.Plug.current_access_token(conn, :secret) # access the token in the secret location
 ```
 

--- a/lib/ex_oauth2_provider.ex
+++ b/lib/ex_oauth2_provider.ex
@@ -42,7 +42,7 @@ defmodule ExOauth2Provider do
 
   ## Example
 
-      ExOauth2Provider.authenticate_token("Jf5rM8hQBc")
+      ExOauth2Provider.authenticate_token("Jf5rM8hQBc", otp_app: :my_app)
 
   ## Response
 
@@ -70,13 +70,13 @@ defmodule ExOauth2Provider do
   defp maybe_revoke_previous_refresh_token({:error, error}, _config), do: {:error, error}
   defp maybe_revoke_previous_refresh_token({:ok, access_token}, config) do
     case Config.refresh_token_revoked_on_use?(config) do
-      true  -> revoke_previous_refresh_token(access_token)
+      true  -> revoke_previous_refresh_token(access_token, config)
       false -> {:ok, access_token}
     end
   end
 
-  defp revoke_previous_refresh_token(access_token) do
-    case AccessTokens.revoke_previous_refresh_token(access_token) do
+  defp revoke_previous_refresh_token(access_token, config) do
+    case AccessTokens.revoke_previous_refresh_token(access_token, config) do
       {:error, _any}       -> {:error, :no_association_found}
       {:ok, _access_token} -> {:ok, access_token}
     end

--- a/lib/ex_oauth2_provider/access_grants/access_grants.ex
+++ b/lib/ex_oauth2_provider/access_grants/access_grants.ex
@@ -14,10 +14,10 @@ defmodule ExOauth2Provider.AccessGrants do
 
   ## Examples
 
-      iex> get_active_grant_for(application, "jE9dk",)
+      iex> get_active_grant_for(application, "jE9dk", otp_app: :my_app)
       %OauthAccessGrant{}
 
-      iex> get_active_grant_for(application, "jE9dk")
+      iex> get_active_grant_for(application, "jE9dk", otp_app: :my_app)
       ** nil
 
   """

--- a/lib/ex_oauth2_provider/access_tokens/access_tokens.ex
+++ b/lib/ex_oauth2_provider/access_tokens/access_tokens.ex
@@ -20,10 +20,10 @@ defmodule ExOauth2Provider.AccessTokens do
 
   ## Examples
 
-      iex> get_by_token("c341a5c7b331ef076eb4954668d54f590e0009e06b81b100191aa22c93044f3d")
+      iex> get_by_token("c341a5c7b331ef076eb4954668d54f590e0009e06b81b100191aa22c93044f3d", otp_app: :my_app)
       %OauthAccessToken{}
 
-      iex> get_by_token("75d72f326a69444a9287ea264617058dbbfe754d7071b8eef8294cbf4e7e0fdc")
+      iex> get_by_token("75d72f326a69444a9287ea264617058dbbfe754d7071b8eef8294cbf4e7e0fdc", otp_app: :my_app)
       nil
 
   """
@@ -39,10 +39,10 @@ defmodule ExOauth2Provider.AccessTokens do
 
   ## Examples
 
-      iex> get_by_refresh_token("c341a5c7b331ef076eb4954668d54f590e0009e06b81b100191aa22c93044f3d")
+      iex> get_by_refresh_token("c341a5c7b331ef076eb4954668d54f590e0009e06b81b100191aa22c93044f3d", otp_app: :my_app)
       %OauthAccessToken{}
 
-      iex> get_by_refresh_token("75d72f326a69444a9287ea264617058dbbfe754d7071b8eef8294cbf4e7e0fdc")
+      iex> get_by_refresh_token("75d72f326a69444a9287ea264617058dbbfe754d7071b8eef8294cbf4e7e0fdc", otp_app: :my_app)
       nil
   """
   @spec get_by_refresh_token(binary(), keyword()) :: AccessToken.t() | nil
@@ -57,10 +57,10 @@ defmodule ExOauth2Provider.AccessTokens do
 
   ## Examples
 
-      iex> get_by_refresh_token_for(application, "c341a5c7b331ef076eb4954668d54f590e0009e06b81b100191aa22c93044f3d")
+      iex> get_by_refresh_token_for(application, "c341a5c7b331ef076eb4954668d54f590e0009e06b81b100191aa22c93044f3d", otp_app: :my_app)
       %OauthAccessToken{}
 
-      iex> get_by_refresh_token_for(application, "75d72f326a69444a9287ea264617058dbbfe754d7071b8eef8294cbf4e7e0fdc")
+      iex> get_by_refresh_token_for(application, "75d72f326a69444a9287ea264617058dbbfe754d7071b8eef8294cbf4e7e0fdc", otp_app: :my_app)
       nil
   """
   @spec get_by_refresh_token_for(Application.t(), binary(), keyword()) :: AccessToken.t() | nil
@@ -75,10 +75,10 @@ defmodule ExOauth2Provider.AccessTokens do
 
   ## Examples
 
-      iex> get_token_for(resource_owner, application, "read write")
+      iex> get_token_for(resource_owner, application, "read write", otp_app: :my_app)
       %OauthAccessToken{}
 
-      iex> get_token_for(resource_owner, application, "read invalid")
+      iex> get_token_for(resource_owner, application, "read invalid", otp_app: :my_app)
       nil
   """
   @spec get_token_for(Schema.t(), Application.t(), binary(), keyword()) :: AccessToken.t() | nil
@@ -95,10 +95,10 @@ defmodule ExOauth2Provider.AccessTokens do
 
   ## Examples
 
-      iex> get_application_token_for(application, "read write")
+      iex> get_application_token_for(application, "read write", otp_app: :my_app)
       %OauthAccessToken{}
 
-      iex> get_application_token_for(application, "read invalid")
+      iex> get_application_token_for(application, "read invalid", otp_app: :my_app)
       nil
   """
   @spec get_application_token_for(Application.t(), binary(), keyword()) :: AccessToken.t() | nil
@@ -150,7 +150,7 @@ defmodule ExOauth2Provider.AccessTokens do
 
   ## Examples
 
-      iex> get_authorized_tokens_for(resource_owner)
+      iex> get_authorized_tokens_for(resource_owner, otp_app: :my_app)
       [%OauthAccessToken{}, ...]
   """
   @spec get_authorized_tokens_for(Schema.t(), keyword()) :: [AccessToken.t()]
@@ -167,13 +167,13 @@ defmodule ExOauth2Provider.AccessTokens do
 
   ## Examples
 
-      iex> create_token(resource_owner, %{application: application, scopes: "read write"})
+      iex> create_token(resource_owner, %{application: application, scopes: "read write"}, otp_app: :my_app)
       {:ok, %OauthAccessToken{}}
 
-      iex> create_token(resource_owner, %{scopes: "read write"})
+      iex> create_token(resource_owner, %{scopes: "read write"}, otp_app: :my_app)
       {:ok, %OauthAccessToken{}}
 
-      iex> create_token(resource_owner, %{expires_in: "invalid"})
+      iex> create_token(resource_owner, %{expires_in: "invalid"}, otp_app: :my_app)
       {:error, %Ecto.Changeset{}}
   """
   @spec create_token(Schema.t(), map(), keyword()) :: {:ok, AccessToken.t()} | {:error, Changeset.t()}
@@ -205,7 +205,7 @@ defmodule ExOauth2Provider.AccessTokens do
 
   ## Examples
 
-      iex> create_application_token(application, %{scopes: "read write"})
+      iex> create_application_token(application, %{scopes: "read write"}, otp_app: :my_app)
       {:ok, %OauthAccessToken{}}
   """
   @spec create_application_token(Schema.t() | nil, map(), keyword()) :: {:ok, AccessToken.t()} | {:error, Changeset.t()}
@@ -239,10 +239,10 @@ defmodule ExOauth2Provider.AccessTokens do
 
   ## Examples
 
-      iex> get_by_previous_refresh_token_for(new_access_token, config)
+      iex> get_by_previous_refresh_token_for(new_access_token, otp_app: :my_app)
       %OauthAccessToken{}
 
-      iex> get_by_previous_refresh_token_for(new_access_token, config)
+      iex> get_by_previous_refresh_token_for(new_access_token, otp_app: :my_app)
       nil
   """
   @spec get_by_previous_refresh_token_for(AccessToken.t(), keyword()) :: AccessToken.t() | nil
@@ -275,10 +275,10 @@ defmodule ExOauth2Provider.AccessTokens do
 
   ## Examples
 
-      iex> revoke_previous_refresh_token(data)
+      iex> revoke_previous_refresh_token(data, otp_app: :my_app)
       {:ok, %OauthAccessToken{}}
 
-      iex> revoke_previous_refresh_token(invalid_data)
+      iex> revoke_previous_refresh_token(invalid_data, otp_app: :my_app)
       {:error, %Ecto.Changeset{}}
   """
   @spec revoke_previous_refresh_token(AccessToken.t()) :: {:ok, AccessToken.t()} | {:error, Changeset.t()}

--- a/lib/ex_oauth2_provider/applications/applications.ex
+++ b/lib/ex_oauth2_provider/applications/applications.ex
@@ -14,10 +14,10 @@ defmodule ExOauth2Provider.Applications do
 
   ## Examples
 
-      iex> get_application!("c341a5c7b331ef076eb4954668d54f590e0009e06b81b100191aa22c93044f3d")
+      iex> get_application!("c341a5c7b331ef076eb4954668d54f590e0009e06b81b100191aa22c93044f3d", otp_app: :my_app)
       %OauthApplication{}
 
-      iex> get_application!("75d72f326a69444a9287ea264617058dbbfe754d7071b8eef8294cbf4e7e0fdc")
+      iex> get_application!("75d72f326a69444a9287ea264617058dbbfe754d7071b8eef8294cbf4e7e0fdc", otp_app: :my_app)
       ** (Ecto.NoResultsError)
 
   """
@@ -35,10 +35,10 @@ defmodule ExOauth2Provider.Applications do
 
   ## Examples
 
-      iex> get_application_for!(owner, "c341a5c7b331ef076eb4954668d54f590e0009e06b81b100191aa22c93044f3d")
+      iex> get_application_for!(owner, "c341a5c7b331ef076eb4954668d54f590e0009e06b81b100191aa22c93044f3d", otp_app: :my_app)
       %OauthApplication{}
 
-      iex> get_application_for!(owner, "75d72f326a69444a9287ea264617058dbbfe754d7071b8eef8294cbf4e7e0fdc")
+      iex> get_application_for!(owner, "75d72f326a69444a9287ea264617058dbbfe754d7071b8eef8294cbf4e7e0fdc", otp_app: :my_app)
       ** (Ecto.NoResultsError)
 
   """
@@ -54,10 +54,10 @@ defmodule ExOauth2Provider.Applications do
 
   ## Examples
 
-      iex> get_application("c341a5c7b331ef076eb4954668d54f590e0009e06b81b100191aa22c93044f3d")
+      iex> get_application("c341a5c7b331ef076eb4954668d54f590e0009e06b81b100191aa22c93044f3d", otp_app: :my_app)
       %OauthApplication{}
 
-      iex> get_application("75d72f326a69444a9287ea264617058dbbfe754d7071b8eef8294cbf4e7e0fdc")
+      iex> get_application("75d72f326a69444a9287ea264617058dbbfe754d7071b8eef8294cbf4e7e0fdc", otp_app: :my_app)
       nil
 
   """
@@ -73,10 +73,10 @@ defmodule ExOauth2Provider.Applications do
 
   ## Examples
 
-      iex> load_application("c341a5c7b331ef076eb4954668d54f590e0009e06b81b100191aa22c93044f3d", "SECRET")
+      iex> load_application("c341a5c7b331ef076eb4954668d54f590e0009e06b81b100191aa22c93044f3d", "SECRET", otp_app: :my_app)
       %OauthApplication{}
 
-      iex> load_application("75d72f326a69444a9287ea264617058dbbfe754d7071b8eef8294cbf4e7e0fdc", "SECRET")
+      iex> load_application("75d72f326a69444a9287ea264617058dbbfe754d7071b8eef8294cbf4e7e0fdc", "SECRET", otp_app: :my_app)
       nil
 
   """
@@ -92,7 +92,7 @@ defmodule ExOauth2Provider.Applications do
 
   ## Examples
 
-      iex> get_applications_for(resource_owner)
+      iex> get_applications_for(resource_owner, otp_app: :my_app)
       [%OauthApplication{}, ...]
 
   """
@@ -109,7 +109,7 @@ defmodule ExOauth2Provider.Applications do
 
   ## Examples
 
-      iex> get_authorized_applications_for(owner)
+      iex> get_authorized_applications_for(owner, otp_app: :my_app)
       [%OauthApplication{},...]
   """
   @spec get_authorized_applications_for(Schema.t(), keyword()) :: [Application.t()]
@@ -130,7 +130,7 @@ defmodule ExOauth2Provider.Applications do
 
   ## Examples
 
-      iex> change_application(application)
+      iex> change_application(application, %{}, otp_app: :my_app)
       {:ok, %OauthApplication{}}
 
   """
@@ -144,10 +144,10 @@ defmodule ExOauth2Provider.Applications do
 
   ## Examples
 
-      iex> create_application(user, %{name: "App", redirect_uri: "http://example.com"})
+      iex> create_application(user, %{name: "App", redirect_uri: "http://example.com"}, otp_app: :my_app)
       {:ok, %OauthApplication{}}
 
-      iex> create_application(user, %{name: ""})
+      iex> create_application(user, %{name: ""}, otp_app: :my_app)
       {:error, %Ecto.Changeset{}}
 
   """
@@ -165,10 +165,10 @@ defmodule ExOauth2Provider.Applications do
 
   ## Examples
 
-      iex> update_application(application, %{name: "Updated App"})
+      iex> update_application(application, %{name: "Updated App"}, otp_app: :my_app)
       {:ok, %OauthApplication{}}
 
-      iex> update_application(application, %{name: ""})
+      iex> update_application(application, %{name: ""}, otp_app: :my_app)
       {:error, %Ecto.Changeset{}}
 
   """
@@ -184,10 +184,10 @@ defmodule ExOauth2Provider.Applications do
 
   ## Examples
 
-      iex> delete_application(application)
+      iex> delete_application(application, otp_app: :my_app)
       {:ok, %OauthApplication{}}
 
-      iex> delete_application(application)
+      iex> delete_application(application, otp_app: :my_app)
       {:error, %Ecto.Changeset{}}
 
   """
@@ -201,7 +201,7 @@ defmodule ExOauth2Provider.Applications do
 
   ## Examples
 
-      iex> revoke_all_access_tokens_for(application, resource_owner)
+      iex> revoke_all_access_tokens_for(application, resource_owner, otp_app: :my_app)
       {:ok, [%OauthAccessToken{}]}
 
   """

--- a/lib/ex_oauth2_provider/oauth2/authorization/strategy/code.ex
+++ b/lib/ex_oauth2_provider/oauth2/authorization/strategy/code.ex
@@ -77,7 +77,8 @@ defmodule ExOauth2Provider.Authorization.Code do
       |> ExOauth2Provider.Authorization.preauthorize(%{
         "client_id" => "Jf5rM8hQBc",
         "response_type" => "code"
-      })
+      }, otp_app: :my_app)
+
   ## Response
       {:ok, client, scopes}                                         # Show request page with client and scopes
       {:error, %{error: error, error_description: _}, http_status}  # Show error page with error and http status
@@ -120,7 +121,8 @@ defmodule ExOauth2Provider.Authorization.Code do
         "scope" => "read write",                  # Optional
         "state" => "46012",                       # Optional
         "redirect_uri" => "https://example.com/"  # Optional
-      })
+      }, otp_app: :my_app)
+
   ## Response
       {:ok, code}                                                  # A grant was generated
       {:error, %{error: error, error_description: _}, http_status} # Error occurred
@@ -165,7 +167,8 @@ defmodule ExOauth2Provider.Authorization.Code do
       |> ExOauth2Provider.Authorization.deny(%{
         "client_id" => "Jf5rM8hQBc",
         "response_type" => "code"
-      })
+      }, otp_app: :my_app)
+
   ## Response type
       {:error, %{error: error, error_description: _}, http_status} # Error occurred
       {:redirect, redirect_uri}                                    # Redirect

--- a/lib/ex_oauth2_provider/oauth2/token.ex
+++ b/lib/ex_oauth2_provider/oauth2/token.ex
@@ -17,7 +17,7 @@ defmodule ExOauth2Provider.Token do
         "grant_type" => "invalid",
         "client_id" => "Jf5rM8hQBc",
         "client_secret" => "secret"
-      })
+      }, otp_app: :my_app)
 
   ## Response
 
@@ -74,7 +74,7 @@ defmodule ExOauth2Provider.Token do
         "client_id" => "Jf5rM8hQBc",
         "client_secret" => "secret",
         "token" => "fi3S9u"
-      })
+      }, otp_app: :my_app)
 
   ## Response
 

--- a/lib/ex_oauth2_provider/oauth2/token/strategy/authorization_code.ex
+++ b/lib/ex_oauth2_provider/oauth2/token/strategy/authorization_code.ex
@@ -20,7 +20,7 @@ defmodule ExOauth2Provider.Token.AuthorizationCode do
         "client_secret" => "secret",
         "redirect_uri" => "https://example.com/",
         "grant_type" => "authorization_code"
-      })
+      }, otp_app: :my_app)
 
   ## Response
       {:ok, access_token}

--- a/lib/ex_oauth2_provider/oauth2/token/strategy/client_credentials.ex
+++ b/lib/ex_oauth2_provider/oauth2/token/strategy/client_credentials.ex
@@ -16,7 +16,7 @@ defmodule ExOauth2Provider.Token.ClientCredentials do
         "grant_type" => "client_credentials",
         "client_id" => "Jf5rM8hQBc",
         "client_secret" => "secret"
-      })
+      }, otp_app: :my_app)
 
   ## Response
       {:ok, access_token}

--- a/lib/ex_oauth2_provider/oauth2/token/strategy/password.ex
+++ b/lib/ex_oauth2_provider/oauth2/token/strategy/password.ex
@@ -20,7 +20,8 @@ defmodule ExOauth2Provider.Token.Password do
         "client_secret" => "secret",
         "username" => "testuser@example.com",
         "password" => "secret"
-      })
+      }, otp_app: :my_app)
+
   ## Response
       {:ok, access_token}
       {:error, %{error: error, error_description: description}, http_status}

--- a/lib/ex_oauth2_provider/oauth2/token/strategy/refresh_token.ex
+++ b/lib/ex_oauth2_provider/oauth2/token/strategy/refresh_token.ex
@@ -19,7 +19,7 @@ defmodule ExOauth2Provider.Token.RefreshToken do
         "client_id" => "Jf5rM8hQBc",
         "client_secret" => "secret",
         "refresh_token" => "1jf6a"
-      })
+      }, otp_app: :my_app)
 
   ## Response
       {:ok, access_token}

--- a/lib/ex_oauth2_provider/oauth2/token/strategy/revoke.ex
+++ b/lib/ex_oauth2_provider/oauth2/token/strategy/revoke.ex
@@ -24,14 +24,16 @@ defmodule ExOauth2Provider.Token.Revoke do
         "client_id" => "Jf5rM8hQBc",
         "client_secret" => "secret",
         "token" => "fi3S9u"
-      })
+      }, otp_app: :my_app)
+
   ## Response
       {:ok, %{}}
 
   ## Example public client
       ExOauth2Provider.Token.revoke(%{
         "token" => "fi3S9u"
-      })
+      }, otp_app: :my_app)
+
   ## Response
       {:ok, %{}}
   """

--- a/lib/ex_oauth2_provider/plug/ensure_authenticated.ex
+++ b/lib/ex_oauth2_provider/plug/ensure_authenticated.ex
@@ -22,7 +22,7 @@ defmodule ExOauth2Provider.Plug.EnsureAuthenticated do
   alias ExOauth2Provider.Plug
 
   @doc false
-  @spec init(keyword) :: keyword()
+  @spec init(keyword()) :: keyword()
   def init(opts), do: opts
 
   @doc false

--- a/lib/ex_oauth2_provider/plug/verify_header.ex
+++ b/lib/ex_oauth2_provider/plug/verify_header.ex
@@ -5,19 +5,19 @@ defmodule ExOauth2Provider.Plug.VerifyHeader do
       Authorization: <token>
 
   ## Example
-      plug ExOauth2Provider.Plug.VerifyHeader
+      plug ExOauth2Provider.Plug.VerifyHeader, otp_app: :my_app
 
   A "realm" can be specified when using the plug.
   Realms are like the name of the token and allow many tokens
   to be sent with a single request.
 
-      plug ExOauth2Provider.Plug.VerifyHeader, realm: "Bearer"
+      plug ExOauth2Provider.Plug.VerifyHeader, otp_app: :my_app, realm: "Bearer"
 
   When a realm is not specified, the first authorization header
   found is used, and assumed to be a raw token
 
   #### example
-      plug ExOauth2Provider.Plug.VerifyHeader
+      plug ExOauth2Provider.Plug.VerifyHeader, otp_app: :my_app
 
       # will take the first auth header
       # Authorization: <token>
@@ -46,7 +46,7 @@ defmodule ExOauth2Provider.Plug.VerifyHeader do
   @spec call(Conn.t(), keyword()) :: Conn.t()
   def call(conn, opts) do
     key    = Keyword.get(opts, :key, :default)
-    config = Keyword.get(opts, :config, [])
+    config = Keyword.take(opts, [:otp_app])
 
     conn
     |> fetch_token(opts)

--- a/lib/mix/ex_oauth2_provider.ex
+++ b/lib/mix/ex_oauth2_provider.ex
@@ -4,6 +4,9 @@ defmodule Mix.ExOauth2Provider do
   """
   alias Mix.Project
 
+  @spec otp_app() :: atom()
+  def otp_app(), do: Keyword.fetch!(Mix.Project.config(), :app)
+
   @doc """
   Raises an exception if the project is an umbrella app.
   """

--- a/lib/mix/ex_oauth2_provider/schema.ex
+++ b/lib/mix/ex_oauth2_provider/schema.ex
@@ -7,7 +7,7 @@ defmodule Mix.ExOauth2Provider.Schema do
   @template """
   defmodule <%= inspect schema.module %> do
     use Ecto.Schema
-    use <%= inspect schema.macro %>
+    use <%= inspect schema.macro %>, otp_app: :<%= otp_app %>
   <%= if schema.binary_id do %>
     @primary_key {:id, :binary_id, autogenerate: true}
     @foreign_key_type :binary_id<% end %>
@@ -35,7 +35,7 @@ defmodule Mix.ExOauth2Provider.Schema do
       binary_id    = Keyword.get(opts, :binary_id, false)
       macro        = schema
       macro_fields = "#{table}_fields"
-      content      = EEx.eval_string(@template, schema: %{module: module, table: table_name, binary_id: binary_id, macro: macro, macro_fields: macro_fields})
+      content      = EEx.eval_string(@template, schema: %{module: module, table: table_name, binary_id: binary_id, macro: macro, macro_fields: macro_fields}, otp_app: context_app)
       dir          = "lib/#{context_app}/#{Macro.underscore(context)}/"
 
       File.mkdir_p!(dir)

--- a/lib/mix/tasks/ex_oauth2_provider.gen.schemas.ex
+++ b/lib/mix/tasks/ex_oauth2_provider.gen.schemas.ex
@@ -16,7 +16,6 @@ defmodule Mix.Tasks.ExOauth2Provider.Gen.Schemas do
   """
   use Mix.Task
 
-  alias ExOauth2Provider.Config
   alias Mix.{ExOauth2Provider, ExOauth2Provider.Schema}
 
   @switches     [binary_id: :boolean, context_app: :string, namespace: :string]
@@ -36,7 +35,7 @@ defmodule Mix.Tasks.ExOauth2Provider.Gen.Schemas do
   defp parse({config, _parsed, _invalid}), do: config
 
   defp create_schema_files(%{binary_id: binary_id, namespace: namespace} = config) do
-   context_app = Map.get(config, :context_app) || Config.otp_app()
+   context_app = Map.get(config, :context_app) || ExOauth2Provider.otp_app()
 
     Schema.create_schema_files(context_app, namespace, binary_id: binary_id)
   end

--- a/lib/mix/tasks/ex_oauth2_provider.install.ex
+++ b/lib/mix/tasks/ex_oauth2_provider.install.ex
@@ -55,7 +55,7 @@ defmodule Mix.Tasks.ExOauth2Provider.Install do
 
   defp print_config_instructions(config, args) do
     [repo | _repos] = Ecto.parse_repo(args)
-    context_app     = Map.get(config, :context_app) || ProviderConfig.otp_app()
+    context_app     = Map.get(config, :context_app) || ExOauth2Provider.otp_app()
     resource_owner  = resource_owner(ProviderConfig.app_base(context_app))
 
     content = Config.gen(context_app, repo: inspect(repo), resource_owner: resource_owner)

--- a/test/ex_oauth2_provider/access_grants/access_grants_test.exs
+++ b/test/ex_oauth2_provider/access_grants/access_grants_test.exs
@@ -12,53 +12,53 @@ defmodule ExOauth2Provider.AccessGrantsTest do
     {:ok, %{user: user, application: Fixtures.application(resource_owner: user, scopes: "public read")}}
   end
 
-  test "get_valid_grant/2", %{user: user, application: application} do
-    {:ok, grant} = AccessGrants.create_grant(user, application, @valid_attrs)
+  test "get_active_grant_for/3", %{user: user, application: application} do
+    {:ok, grant} = AccessGrants.create_grant(user, application, @valid_attrs, otp_app: :ex_oauth2_provider)
 
-    assert %OauthAccessGrant{id: id} = AccessGrants.get_active_grant_for(application, grant.token)
+    assert %OauthAccessGrant{id: id} = AccessGrants.get_active_grant_for(application, grant.token, otp_app: :ex_oauth2_provider)
     assert id == grant.id
 
     different_application = Fixtures.application(resource_owner: user, uid: "2")
-    refute AccessGrants.get_active_grant_for(different_application, grant.token)
+    refute AccessGrants.get_active_grant_for(different_application, grant.token, otp_app: :ex_oauth2_provider)
   end
 
-  describe "create_grant/3" do
+  describe "create_grant/4" do
     test "with valid attributes", %{user: user, application: application} do
-      assert {:ok, %OauthAccessGrant{} = grant} = AccessGrants.create_grant(user, application, @valid_attrs)
+      assert {:ok, %OauthAccessGrant{} = grant} = AccessGrants.create_grant(user, application, @valid_attrs, otp_app: :ex_oauth2_provider)
       assert grant.resource_owner == user
       assert grant.application == application
       assert grant.scopes == "public"
     end
 
     test "adds random token", %{user: user, application: application} do
-      {:ok, grant} = AccessGrants.create_grant(user, application, @valid_attrs)
-      {:ok, grant2} = AccessGrants.create_grant(user, application, @valid_attrs)
+      {:ok, grant} = AccessGrants.create_grant(user, application, @valid_attrs, otp_app: :ex_oauth2_provider)
+      {:ok, grant2} = AccessGrants.create_grant(user, application, @valid_attrs, otp_app: :ex_oauth2_provider)
       assert grant.token != grant2.token
     end
 
     test "with missing expires_in", %{application: application, user: user} do
       attrs = Map.merge(@valid_attrs, %{expires_in: nil})
 
-      assert {:error, changeset} = AccessGrants.create_grant(user, application, attrs)
+      assert {:error, changeset} = AccessGrants.create_grant(user, application, attrs, otp_app: :ex_oauth2_provider)
       assert changeset.errors[:expires_in] == {"can't be blank", [validation: :required]}
     end
 
     test "with missing redirect_uri", %{application: application, user: user} do
       attrs = Map.merge(@valid_attrs, %{redirect_uri: nil})
 
-      assert {:error, changeset} = AccessGrants.create_grant(user, application, attrs)
+      assert {:error, changeset} = AccessGrants.create_grant(user, application, attrs, otp_app: :ex_oauth2_provider)
       assert changeset.errors[:redirect_uri] == {"can't be blank", [validation: :required]}
     end
 
     test "with invalid scopes", %{application: application, user: user} do
       attrs = Map.merge(@valid_attrs, %{scopes: "write"})
 
-      assert {:error, changeset} = AccessGrants.create_grant(user, application, attrs)
+      assert {:error, changeset} = AccessGrants.create_grant(user, application, attrs, otp_app: :ex_oauth2_provider)
       assert changeset.errors[:scopes] == {"not in permitted scopes list: \"public read\"", []}
     end
   end
 
-  describe "create_grant/3 with no application scopes" do
+  describe "create_grant/4 with no application scopes" do
     setup %{user: user, application: application} do
       application = Map.merge(application, %{scopes: ""})
       %{user: user, application: application}
@@ -67,14 +67,14 @@ defmodule ExOauth2Provider.AccessGrantsTest do
     test "with invalid scopes", %{application: application, user: user} do
       attrs = Map.merge(@valid_attrs, %{scopes: "invalid"})
 
-      assert {:error, changeset} = AccessGrants.create_grant(user, application, attrs)
+      assert {:error, changeset} = AccessGrants.create_grant(user, application, attrs, otp_app: :ex_oauth2_provider)
       assert changeset.errors[:scopes] == {"not in permitted scopes list: [\"public\", \"read\", \"write\"]", []}
     end
 
     test "with valid attributes", %{application: application, user: user} do
       attrs = Map.merge(@valid_attrs, %{scopes: "write"})
 
-      assert {:ok, grant} = AccessGrants.create_grant(user, application, attrs)
+      assert {:ok, grant} = AccessGrants.create_grant(user, application, attrs, otp_app: :ex_oauth2_provider)
       assert grant.scopes == "write"
     end
   end

--- a/test/ex_oauth2_provider/access_tokens/access_tokens_test.exs
+++ b/test/ex_oauth2_provider/access_tokens/access_tokens_test.exs
@@ -10,201 +10,201 @@ defmodule ExOauth2Provider.AccessTokensTest do
     {:ok, %{user: user, application: Fixtures.application(resource_owner: user)}}
   end
 
-  test "get_by_token/1", %{user: user} do
-    assert {:ok, access_token} = AccessTokens.create_token(user)
+  test "get_by_token/2", %{user: user} do
+    assert {:ok, access_token} = AccessTokens.create_token(user, %{}, otp_app: :ex_oauth2_provider)
 
-    assert %OauthAccessToken{id: id} = AccessTokens.get_by_token(access_token.token)
+    assert %OauthAccessToken{id: id} = AccessTokens.get_by_token(access_token.token, otp_app: :ex_oauth2_provider)
     assert id == access_token.id
   end
 
   test "get_by_refresh_token/2", %{user: user} do
-    assert {:ok, access_token} = AccessTokens.create_token(user, %{use_refresh_token: true})
+    assert {:ok, access_token} = AccessTokens.create_token(user, %{use_refresh_token: true}, otp_app: :ex_oauth2_provider)
 
-    assert %OauthAccessToken{id: id} = AccessTokens.get_by_refresh_token(access_token.refresh_token)
+    assert %OauthAccessToken{id: id} = AccessTokens.get_by_refresh_token(access_token.refresh_token, otp_app: :ex_oauth2_provider)
     assert id == access_token.id
   end
 
-  describe "get_by_previous_refresh_token_for/2" do
+  describe "get_by_previous_refresh_token_for/3" do
     test "with resource owner", %{user: user} do
-      {:ok, old_access_token} = AccessTokens.create_token(user, %{use_refresh_token: true})
-      {:ok, new_access_token} = AccessTokens.create_token(user, %{use_refresh_token: true, previous_refresh_token: old_access_token})
+      {:ok, old_access_token} = AccessTokens.create_token(user, %{use_refresh_token: true}, otp_app: :ex_oauth2_provider)
+      {:ok, new_access_token} = AccessTokens.create_token(user, %{use_refresh_token: true, previous_refresh_token: old_access_token}, otp_app: :ex_oauth2_provider)
 
-      assert %OauthAccessToken{id: id} = AccessTokens.get_by_previous_refresh_token_for(new_access_token, [])
+      assert %OauthAccessToken{id: id} = AccessTokens.get_by_previous_refresh_token_for(new_access_token, otp_app: :ex_oauth2_provider)
       assert id == old_access_token.id
 
-      refute AccessTokens.get_by_previous_refresh_token_for(old_access_token, [])
+      refute AccessTokens.get_by_previous_refresh_token_for(old_access_token, otp_app: :ex_oauth2_provider)
 
-      {:ok, new_access_token_different_user} = AccessTokens.create_token(Fixtures.resource_owner(), %{use_refresh_token: true, previous_refresh_token: old_access_token})
+      {:ok, new_access_token_different_user} = AccessTokens.create_token(Fixtures.resource_owner(), %{use_refresh_token: true, previous_refresh_token: old_access_token}, otp_app: :ex_oauth2_provider)
 
-      refute AccessTokens.get_by_previous_refresh_token_for(new_access_token_different_user, [])
+      refute AccessTokens.get_by_previous_refresh_token_for(new_access_token_different_user, otp_app: :ex_oauth2_provider)
     end
 
     test "with application", %{user: user, application: application} do
-      {:ok, old_access_token} = AccessTokens.create_token(user, %{application: application, use_refresh_token: true})
-      {:ok, new_access_token} = AccessTokens.create_token(user, %{application: application, use_refresh_token: true, previous_refresh_token: old_access_token})
+      {:ok, old_access_token} = AccessTokens.create_token(user, %{application: application, use_refresh_token: true}, otp_app: :ex_oauth2_provider)
+      {:ok, new_access_token} = AccessTokens.create_token(user, %{application: application, use_refresh_token: true, previous_refresh_token: old_access_token}, otp_app: :ex_oauth2_provider)
 
-      assert %OauthAccessToken{id: id} = AccessTokens.get_by_previous_refresh_token_for(new_access_token, [])
+      assert %OauthAccessToken{id: id} = AccessTokens.get_by_previous_refresh_token_for(new_access_token, otp_app: :ex_oauth2_provider)
       assert id == old_access_token.id
 
-      refute AccessTokens.get_by_previous_refresh_token_for(old_access_token, [])
+      refute AccessTokens.get_by_previous_refresh_token_for(old_access_token, otp_app: :ex_oauth2_provider)
 
-      {:ok, new_access_token_different_user} = AccessTokens.create_token(Fixtures.resource_owner(), %{application: application, use_refresh_token: true, previous_refresh_token: old_access_token})
-      refute AccessTokens.get_by_previous_refresh_token_for(new_access_token_different_user, [])
+      {:ok, new_access_token_different_user} = AccessTokens.create_token(Fixtures.resource_owner(), %{application: application, use_refresh_token: true, previous_refresh_token: old_access_token}, otp_app: :ex_oauth2_provider)
+      refute AccessTokens.get_by_previous_refresh_token_for(new_access_token_different_user, otp_app: :ex_oauth2_provider)
 
       new_application = Fixtures.application(resource_owner: user, uid: "new_app")
-      {:ok, new_access_token_different_app} = AccessTokens.create_token(user, %{application: new_application, use_refresh_token: true, previous_refresh_token: old_access_token})
+      {:ok, new_access_token_different_app} = AccessTokens.create_token(user, %{application: new_application, use_refresh_token: true, previous_refresh_token: old_access_token}, otp_app: :ex_oauth2_provider)
 
-      refute AccessTokens.get_by_previous_refresh_token_for(new_access_token_different_app, [])
+      refute AccessTokens.get_by_previous_refresh_token_for(new_access_token_different_app, otp_app: :ex_oauth2_provider)
     end
   end
 
-  describe "get_token_for/3" do
+  describe "get_token_for/4" do
     test "fetches for resource owner", %{user: user, application: application} do
-      {:ok, access_token1} = AccessTokens.create_token(user)
+      {:ok, access_token1} = AccessTokens.create_token(user, %{}, otp_app: :ex_oauth2_provider)
       inserted_at = QueryHelpers.timestamp(OauthAccessToken, :inserted_at, seconds: -1)
       QueryHelpers.change!(access_token1, inserted_at: inserted_at)
-      {:ok, access_token2} = AccessTokens.create_token(user)
-      {:ok, _access_token_with_application} = AccessTokens.create_token(user, %{application: application})
+      {:ok, access_token2} = AccessTokens.create_token(user, %{}, otp_app: :ex_oauth2_provider)
+      {:ok, _access_token_with_application} = AccessTokens.create_token(user, %{application: application}, otp_app: :ex_oauth2_provider)
 
-      assert %OauthAccessToken{id: id} = AccessTokens.get_token_for(user, nil, nil)
+      assert %OauthAccessToken{id: id} = AccessTokens.get_token_for(user, nil, nil, otp_app: :ex_oauth2_provider)
       assert id == access_token2.id
 
-      refute AccessTokens.get_token_for(Fixtures.resource_owner(), nil, nil)
+      refute AccessTokens.get_token_for(Fixtures.resource_owner(), nil, nil, otp_app: :ex_oauth2_provider)
     end
 
     test "with application", %{user: user, application: application} do
-      {:ok, access_token1} = AccessTokens.create_token(user, %{application: application})
+      {:ok, access_token1} = AccessTokens.create_token(user, %{application: application}, otp_app: :ex_oauth2_provider)
       inserted_at = QueryHelpers.timestamp(OauthAccessToken, :inserted_at, seconds: -1)
       QueryHelpers.change!(access_token1, inserted_at: inserted_at)
-      {:ok, access_token2} = AccessTokens.create_token(user, %{application: application})
-      {:ok, _access_token_without_application} = AccessTokens.create_token(user)
+      {:ok, access_token2} = AccessTokens.create_token(user, %{application: application}, otp_app: :ex_oauth2_provider)
+      {:ok, _access_token_without_application} = AccessTokens.create_token(user, %{}, otp_app: :ex_oauth2_provider)
 
-      assert %OauthAccessToken{id: id} = AccessTokens.get_token_for(user, application, nil)
+      assert %OauthAccessToken{id: id} = AccessTokens.get_token_for(user, application, nil, otp_app: :ex_oauth2_provider)
       assert id == access_token2.id
     end
 
     test "with scopes", %{user: user} do
-      {:ok, access_token1} = AccessTokens.create_token(user, %{scopes: "public"})
-      {:ok, access_token2} = AccessTokens.create_token(user, %{scopes: "read write"})
+      {:ok, access_token1} = AccessTokens.create_token(user, %{scopes: "public"}, otp_app: :ex_oauth2_provider)
+      {:ok, access_token2} = AccessTokens.create_token(user, %{scopes: "read write"}, otp_app: :ex_oauth2_provider)
 
-      assert %OauthAccessToken{id: id} = AccessTokens.get_token_for(user, nil, "public")
+      assert %OauthAccessToken{id: id} = AccessTokens.get_token_for(user, nil, "public", otp_app: :ex_oauth2_provider)
       assert id == access_token1.id
 
-      assert %OauthAccessToken{id: id} = AccessTokens.get_token_for(user, nil, "write read")
+      assert %OauthAccessToken{id: id} = AccessTokens.get_token_for(user, nil, "write read", otp_app: :ex_oauth2_provider)
       assert id == access_token2.id
 
-      refute AccessTokens.get_token_for(user, nil, "other_read")
+      refute AccessTokens.get_token_for(user, nil, "other_read", otp_app: :ex_oauth2_provider)
     end
 
     test "filters revoked", %{user: user} do
-      {:ok, access_token} = AccessTokens.create_token(user)
-      assert AccessTokens.get_token_for(user, nil, nil)
+      {:ok, access_token} = AccessTokens.create_token(user, %{}, otp_app: :ex_oauth2_provider)
+      assert AccessTokens.get_token_for(user, nil, nil, otp_app: :ex_oauth2_provider)
 
       AccessTokens.revoke(access_token)
-      refute AccessTokens.get_token_for(user, nil, nil)
+      refute AccessTokens.get_token_for(user, nil, nil, otp_app: :ex_oauth2_provider)
     end
 
     test "filters expired", %{user: user} do
-      {:ok, access_token} = AccessTokens.create_token(user)
+      {:ok, access_token} = AccessTokens.create_token(user, %{}, otp_app: :ex_oauth2_provider)
 
-      assert AccessTokens.get_token_for(user, nil, nil)
+      assert AccessTokens.get_token_for(user, nil, nil, otp_app: :ex_oauth2_provider)
 
       inserted_at = QueryHelpers.timestamp(access_token.__struct__, :inserted_at, seconds: -access_token.expires_in)
       QueryHelpers.change!(access_token, inserted_at: inserted_at)
 
-      refute AccessTokens.get_token_for(user, nil, nil)
+      refute AccessTokens.get_token_for(user, nil, nil, otp_app: :ex_oauth2_provider)
     end
   end
 
-  describe "get_application_token_for/2" do
+  describe "get_application_token_for/3" do
     test "fetches", %{application: application} do
-      {:ok, access_token1} = AccessTokens.create_application_token(application)
+      {:ok, access_token1} = AccessTokens.create_application_token(application, %{}, otp_app: :ex_oauth2_provider)
       inserted_at = QueryHelpers.timestamp(OauthAccessToken, :inserted_at, seconds: -1)
       QueryHelpers.change!(access_token1, inserted_at: inserted_at)
-      {:ok, access_token2} = AccessTokens.create_application_token(application)
+      {:ok, access_token2} = AccessTokens.create_application_token(application, %{}, otp_app: :ex_oauth2_provider)
 
-      assert %OauthAccessToken{id: id} = AccessTokens.get_application_token_for(application, nil)
+      assert %OauthAccessToken{id: id} = AccessTokens.get_application_token_for(application, nil, otp_app: :ex_oauth2_provider)
       assert id == access_token2.id
 
-      refute AccessTokens.get_application_token_for(Fixtures.application(uid: "application-2"), nil)
+      refute AccessTokens.get_application_token_for(Fixtures.application(uid: "application-2"), nil, otp_app: :ex_oauth2_provider)
     end
   end
 
-  test "get_authorized_tokens_for/1", %{user: user, application: application} do
-    {:ok, access_token} = AccessTokens.create_token(user, %{application: application})
+  test "get_authorized_tokens_for/2", %{user: user, application: application} do
+    {:ok, access_token} = AccessTokens.create_token(user, %{application: application}, otp_app: :ex_oauth2_provider)
 
-    assert [%OauthAccessToken{id: id}] = AccessTokens.get_authorized_tokens_for(user)
+    assert [%OauthAccessToken{id: id}] = AccessTokens.get_authorized_tokens_for(user, otp_app: :ex_oauth2_provider)
     assert id == access_token.id
 
     QueryHelpers.change!(access_token, expires_in: -1)
 
-    assert [%OauthAccessToken{id: id}] = AccessTokens.get_authorized_tokens_for(user)
+    assert [%OauthAccessToken{id: id}] = AccessTokens.get_authorized_tokens_for(user, otp_app: :ex_oauth2_provider)
     assert id == access_token.id
 
-    AccessTokens.revoke(access_token)
-    assert AccessTokens.get_authorized_tokens_for(user) == []
+    AccessTokens.revoke(access_token, otp_app: :ex_oauth2_provider)
+    assert AccessTokens.get_authorized_tokens_for(user, otp_app: :ex_oauth2_provider) == []
 
-    assert AccessTokens.get_authorized_tokens_for(Fixtures.resource_owner()) == []
+    assert AccessTokens.get_authorized_tokens_for(Fixtures.resource_owner(), otp_app: :ex_oauth2_provider) == []
   end
 
-  describe "create_token/2" do
+  describe "create_token/3" do
     test "with valid attributes", %{user: user} do
-      assert {:ok, access_token} = AccessTokens.create_token(user)
+      assert {:ok, access_token} = AccessTokens.create_token(user, %{}, otp_app: :ex_oauth2_provider)
       assert access_token.resource_owner_id == user.id
       assert is_nil(access_token.application_id)
     end
 
     test "with resource owner and application", %{user: user, application: application} do
-      {:ok, access_token} = AccessTokens.create_token(user, %{application: application})
+      {:ok, access_token} = AccessTokens.create_token(user, %{application: application}, otp_app: :ex_oauth2_provider)
       assert access_token.resource_owner_id == user.id
       assert access_token.application_id == application.id
     end
 
     test "adds random token", %{user: user} do
-      {:ok, access_token} = AccessTokens.create_token(user)
-      {:ok, access_token2} = AccessTokens.create_token(user)
+      {:ok, access_token} = AccessTokens.create_token(user, %{}, otp_app: :ex_oauth2_provider)
+      {:ok, access_token2} = AccessTokens.create_token(user, %{}, otp_app: :ex_oauth2_provider)
       assert access_token.token != access_token2.token
     end
 
     test "with custom access token generator", %{user: user} do
-      {:ok, access_token} = AccessTokens.create_token(user, %{}, access_token_generator: {__MODULE__, :access_token_generator})
+      {:ok, access_token} = AccessTokens.create_token(user, %{}, otp_app: :ex_oauth2_provider, access_token_generator: {__MODULE__, :access_token_generator})
       assert access_token.token == "custom_generated-#{user.id}"
     end
 
     test "adds previous_refresh_token", %{user: user} do
-      {:ok, old_access_token} = AccessTokens.create_token(user, %{use_refresh_token: true})
-      {:ok, new_access_token} = AccessTokens.create_token(user, %{use_refresh_token: true, previous_refresh_token: old_access_token})
+      {:ok, old_access_token} = AccessTokens.create_token(user, %{use_refresh_token: true}, otp_app: :ex_oauth2_provider)
+      {:ok, new_access_token} = AccessTokens.create_token(user, %{use_refresh_token: true, previous_refresh_token: old_access_token}, otp_app: :ex_oauth2_provider)
       assert new_access_token.previous_refresh_token == old_access_token.refresh_token
     end
 
     test "adds random refresh token", %{user: user} do
-      {:ok, access_token} = AccessTokens.create_token(user, %{use_refresh_token: true})
-      {:ok, access_token2} = AccessTokens.create_token(user, %{use_refresh_token: true})
+      {:ok, access_token} = AccessTokens.create_token(user, %{use_refresh_token: true}, otp_app: :ex_oauth2_provider)
+      {:ok, access_token2} = AccessTokens.create_token(user, %{use_refresh_token: true}, otp_app: :ex_oauth2_provider)
       assert access_token.refresh_token != access_token2.refresh_token
     end
 
     test "doesn't add refresh token when disabled", %{user: user} do
-      {:ok, access_token} = AccessTokens.create_token(user, %{use_refresh_token: false})
+      {:ok, access_token} = AccessTokens.create_token(user, %{use_refresh_token: false}, otp_app: :ex_oauth2_provider)
       assert is_nil(access_token.refresh_token)
     end
 
     test "with no scopes", %{user: user} do
-      assert {:ok, access_token} = AccessTokens.create_token(user)
+      assert {:ok, access_token} = AccessTokens.create_token(user, %{}, otp_app: :ex_oauth2_provider)
       assert access_token.scopes == "public"
     end
 
     test "with custom scopes", %{user: user} do
-      assert {:ok, access_token} = AccessTokens.create_token(user, %{scopes: "read"})
+      assert {:ok, access_token} = AccessTokens.create_token(user, %{scopes: "read"}, otp_app: :ex_oauth2_provider)
       assert access_token.scopes == "read"
     end
 
     test "with invalid scopes", %{user: user} do
-      assert {:error, changeset} = AccessTokens.create_token(user, %{scopes: "invalid"})
+      assert {:error, changeset} = AccessTokens.create_token(user, %{scopes: "invalid"}, otp_app: :ex_oauth2_provider)
       assert changeset.errors[:scopes] == {"not in permitted scopes list: [\"public\", \"read\", \"write\"]", []}
     end
   end
 
-  describe "create_token/2 with application scopes" do
+  describe "create_token/3 with application scopes" do
     setup %{user: user, application: application} do
        application = Map.merge(application, %{scopes: "public app:write app:read"})
 
@@ -212,43 +212,43 @@ defmodule ExOauth2Provider.AccessTokensTest do
     end
 
     test "with no scopes", %{user: user, application: application} do
-      assert {:ok, access_token} = AccessTokens.create_token(user, %{application: application})
+      assert {:ok, access_token} = AccessTokens.create_token(user, %{application: application}, otp_app: :ex_oauth2_provider)
       assert access_token.scopes == "public"
     end
 
     test "with custom scopes", %{user: user, application: application} do
       application = Map.merge(application, %{scopes: "app:read"})
-      assert {:ok, access_token} = AccessTokens.create_token(user, %{scopes: "app:read", application: application})
+      assert {:ok, access_token} = AccessTokens.create_token(user, %{scopes: "app:read", application: application}, otp_app: :ex_oauth2_provider)
       assert access_token.scopes == "app:read"
     end
 
     test "with invalid scopes", %{user: user, application: application} do
       application = Map.merge(application, %{scopes: "app:read"})
-      assert {:error, changeset} = AccessTokens.create_token(user, %{application: application, scopes: "app:write"})
+      assert {:error, changeset} = AccessTokens.create_token(user, %{application: application, scopes: "app:write"}, otp_app: :ex_oauth2_provider)
       assert changeset.errors[:scopes] == {"not in permitted scopes list: \"app:read\"", []}
     end
   end
 
-  test "create_application_token/2", %{application: application} do
-    {:ok, access_token} = AccessTokens.create_application_token(application)
+  test "create_application_token/3", %{application: application} do
+    {:ok, access_token} = AccessTokens.create_application_token(application, %{}, otp_app: :ex_oauth2_provider)
     assert is_nil(access_token.resource_owner_id)
     assert access_token.application_id == application.id
   end
 
-  describe "revoke/1" do
+  describe "revoke/2" do
     test "revokes token", %{user: user} do
-      {:ok, access_token} = AccessTokens.create_token(user)
+      {:ok, access_token} = AccessTokens.create_token(user, %{}, otp_app: :ex_oauth2_provider)
 
-      assert {:ok, access_token} = AccessTokens.revoke(access_token)
+      assert {:ok, access_token} = AccessTokens.revoke(access_token, otp_app: :ex_oauth2_provider)
       assert AccessTokens.is_revoked?(access_token) == true
     end
 
     test "doesn't revoke revoked tokens", %{user: user} do
-      {:ok, access_token} = AccessTokens.create_token(user)
+      {:ok, access_token} = AccessTokens.create_token(user, %{}, otp_app: :ex_oauth2_provider)
       revoked_at = QueryHelpers.timestamp(OauthAccessToken, :revoked_at, seconds: -86_400)
       access_token = Map.merge(access_token, %{revoked_at: revoked_at})
 
-      {:ok, access_token2} = AccessTokens.revoke(access_token)
+      {:ok, access_token2} = AccessTokens.revoke(access_token, otp_app: :ex_oauth2_provider)
       assert access_token2.revoked_at == access_token.revoked_at
     end
   end

--- a/test/ex_oauth2_provider/applications/applications_test.exs
+++ b/test/ex_oauth2_provider/applications/applications_test.exs
@@ -12,80 +12,80 @@ defmodule ExOauth2Provider.ApplicationsTest do
     {:ok, %{user: Fixtures.resource_owner()}}
   end
 
-  test "get_applications_for/1", %{user: user} do
-    assert {:ok, application} = Applications.create_application(user, @valid_attrs)
-    assert {:ok, _application} = Applications.create_application(Fixtures.resource_owner(), @valid_attrs)
+  test "get_applications_for/2", %{user: user} do
+    assert {:ok, application} = Applications.create_application(user, @valid_attrs, otp_app: :ex_oauth2_provider)
+    assert {:ok, _application} = Applications.create_application(Fixtures.resource_owner(), @valid_attrs, otp_app: :ex_oauth2_provider)
 
-    assert [%OauthApplication{id: id}] = Applications.get_applications_for(user)
+    assert [%OauthApplication{id: id}] = Applications.get_applications_for(user, otp_app: :ex_oauth2_provider)
     assert id == application.id
   end
 
-  test "get_application!/1", %{user: user} do
-    assert {:ok, application} = Applications.create_application(user, @valid_attrs)
+  test "get_application!/2", %{user: user} do
+    assert {:ok, application} = Applications.create_application(user, @valid_attrs, otp_app: :ex_oauth2_provider)
 
-    assert %OauthApplication{id: id} = Applications.get_application!(application.uid)
+    assert %OauthApplication{id: id} = Applications.get_application!(application.uid, otp_app: :ex_oauth2_provider)
     assert id == application.id
   end
 
-  test "get_application/1", %{user: user} do
-    assert {:ok, application} = Applications.create_application(user, @valid_attrs)
+  test "get_application/2", %{user: user} do
+    assert {:ok, application} = Applications.create_application(user, @valid_attrs, otp_app: :ex_oauth2_provider)
 
-    assert %OauthApplication{id: id} = Applications.get_application(application.uid)
+    assert %OauthApplication{id: id} = Applications.get_application(application.uid, otp_app: :ex_oauth2_provider)
     assert id == application.id
   end
 
-  test "get_application_for!/1", %{user: user} do
-    {:ok, application} = Applications.create_application(user, @valid_attrs)
+  test "get_application_for!/2", %{user: user} do
+    {:ok, application} = Applications.create_application(user, @valid_attrs, otp_app: :ex_oauth2_provider)
 
-    assert %OauthApplication{id: id} = Applications.get_application_for!(user, application.uid)
+    assert %OauthApplication{id: id} = Applications.get_application_for!(user, application.uid, otp_app: :ex_oauth2_provider)
     assert id == application.id
 
     assert_raise Ecto.NoResultsError, fn ->
-      Applications.get_application_for!(Fixtures.resource_owner(), application.uid)
+      Applications.get_application_for!(Fixtures.resource_owner(), application.uid, otp_app: :ex_oauth2_provider)
     end
   end
 
-  test "get_authorized_applications_for/1", %{user: user} do
+  test "get_authorized_applications_for/2", %{user: user} do
     application = Fixtures.application()
     application2 = Fixtures.application(uid: "newapp")
-    assert {:ok, token} = AccessTokens.create_token(user, %{application: application})
-    assert {:ok, _token} = AccessTokens.create_token(user, %{application: application2})
+    assert {:ok, token} = AccessTokens.create_token(user, %{application: application}, otp_app: :ex_oauth2_provider)
+    assert {:ok, _token} = AccessTokens.create_token(user, %{application: application2}, otp_app: :ex_oauth2_provider)
 
-    assert Applications.get_authorized_applications_for(user) == [application, application2]
-    assert Applications.get_authorized_applications_for(Fixtures.resource_owner()) == []
+    assert Applications.get_authorized_applications_for(user, otp_app: :ex_oauth2_provider) == [application, application2]
+    assert Applications.get_authorized_applications_for(Fixtures.resource_owner(), otp_app: :ex_oauth2_provider) == []
 
-    AccessTokens.revoke(token)
-    assert Applications.get_authorized_applications_for(user) == [application2]
+    AccessTokens.revoke(token, otp_app: :ex_oauth2_provider)
+    assert Applications.get_authorized_applications_for(user, otp_app: :ex_oauth2_provider) == [application2]
   end
 
-  describe "create_application/2" do
+  describe "create_application/3" do
     test "with valid attributes", %{user: user} do
-      assert {:ok, application} = Applications.create_application(user, @valid_attrs)
+      assert {:ok, application} = Applications.create_application(user, @valid_attrs, otp_app: :ex_oauth2_provider)
       assert application.name == @valid_attrs.name
       assert application.scopes == "public"
     end
 
     test "with invalid attributes", %{user: user} do
-      assert {:error, changeset} = Applications.create_application(user, @invalid_attrs)
+      assert {:error, changeset} = Applications.create_application(user, @invalid_attrs, otp_app: :ex_oauth2_provider)
       assert changeset.errors[:name]
     end
 
     test "with invalid scopes", %{user: user} do
       attrs = Map.merge(@valid_attrs, %{scopes: "invalid"})
 
-      assert {:error, %Ecto.Changeset{}} = Applications.create_application(user, attrs)
+      assert {:error, %Ecto.Changeset{}} = Applications.create_application(user, attrs, otp_app: :ex_oauth2_provider)
     end
 
     test "with limited scopes", %{user: user} do
       attrs = Map.merge(@valid_attrs, %{scopes: "read write"})
 
-      assert {:ok, application} = Applications.create_application(user, attrs)
+      assert {:ok, application} = Applications.create_application(user, attrs, otp_app: :ex_oauth2_provider)
       assert application.scopes == "read write"
     end
 
     test "adds random secret", %{user: user} do
-      {:ok, application} = Applications.create_application(user, @valid_attrs)
-      {:ok, application2} = Applications.create_application(user, @valid_attrs)
+      {:ok, application} = Applications.create_application(user, @valid_attrs, otp_app: :ex_oauth2_provider)
+      {:ok, application2} = Applications.create_application(user, @valid_attrs, otp_app: :ex_oauth2_provider)
 
       assert application.secret != application2.secret
     end
@@ -93,51 +93,51 @@ defmodule ExOauth2Provider.ApplicationsTest do
     test "permits empty string secret", %{user: user} do
       attrs = Map.merge(@valid_attrs, %{secret: ""})
 
-      assert {:ok, application} = Applications.create_application(user, attrs)
+      assert {:ok, application} = Applications.create_application(user, attrs, otp_app: :ex_oauth2_provider)
       assert application.secret == ""
     end
 
     test "adds random uid", %{user: user} do
-      {:ok, application} = Applications.create_application(user, @valid_attrs)
-      {:ok, application2} = Applications.create_application(user, @valid_attrs)
+      {:ok, application} = Applications.create_application(user, @valid_attrs, otp_app: :ex_oauth2_provider)
+      {:ok, application2} = Applications.create_application(user, @valid_attrs, otp_app: :ex_oauth2_provider)
       assert application.uid != application2.uid
     end
 
     test "adds custom uid", %{user: user} do
-      {:ok, application} = Applications.create_application(user, Map.merge(@valid_attrs, %{uid: "custom"}))
+      {:ok, application} = Applications.create_application(user, Map.merge(@valid_attrs, %{uid: "custom"}), otp_app: :ex_oauth2_provider)
       assert application.uid == "custom"
     end
 
     test "adds custom secret", %{user: user} do
-      {:ok, application} = Applications.create_application(user, Map.merge(@valid_attrs, %{secret: "custom"}))
+      {:ok, application} = Applications.create_application(user, Map.merge(@valid_attrs, %{secret: "custom"}), otp_app: :ex_oauth2_provider)
       assert application.secret == "custom"
     end
   end
 
-  test "update_application/2", %{user: user} do
-    assert {:ok, application} = Applications.create_application(user, @valid_attrs)
+  test "update_application/3", %{user: user} do
+    assert {:ok, application} = Applications.create_application(user, @valid_attrs, otp_app: :ex_oauth2_provider)
 
-    assert {:ok, application} = Applications.update_application(application, %{name: "Updated App"})
+    assert {:ok, application} = Applications.update_application(application, %{name: "Updated App"}, otp_app: :ex_oauth2_provider)
     assert application.name == "Updated App"
   end
 
-  test "delete_application/1", %{user: user} do
-    {:ok, application} = Applications.create_application(user, @valid_attrs)
+  test "delete_application/2", %{user: user} do
+    {:ok, application} = Applications.create_application(user, @valid_attrs, otp_app: :ex_oauth2_provider)
 
-    assert {:ok, _appliction} = Applications.delete_application(application)
+    assert {:ok, _appliction} = Applications.delete_application(application, otp_app: :ex_oauth2_provider)
     assert_raise Ecto.NoResultsError, fn ->
-      Applications.get_application!(application.uid)
+      Applications.get_application!(application.uid, otp_app: :ex_oauth2_provider)
     end
   end
 
-  test "revoke_all_access_tokens_for/2", %{user: user} do
+  test "revoke_all_access_tokens_for/3", %{user: user} do
     application = Fixtures.application()
-    {:ok, token} = AccessTokens.create_token(user, %{application: application})
-    {:ok, token2} = AccessTokens.create_token(user, %{application: application})
-    {:ok, token3} = AccessTokens.create_token(user, %{application: application})
+    {:ok, token} = AccessTokens.create_token(user, %{application: application}, otp_app: :ex_oauth2_provider)
+    {:ok, token2} = AccessTokens.create_token(user, %{application: application}, otp_app: :ex_oauth2_provider)
+    {:ok, token3} = AccessTokens.create_token(user, %{application: application}, otp_app: :ex_oauth2_provider)
     AccessTokens.revoke(token3)
 
-    assert {:ok, objects} = Applications.revoke_all_access_tokens_for(application, user)
+    assert {:ok, objects} = Applications.revoke_all_access_tokens_for(application, user, otp_app: :ex_oauth2_provider)
     assert Enum.count(objects) == 2
 
     assert AccessTokens.is_revoked?(Repo.get!(OauthAccessToken, token.id))

--- a/test/ex_oauth2_provider/oauth2/authorization_test.exs
+++ b/test/ex_oauth2_provider/oauth2/authorization_test.exs
@@ -20,59 +20,59 @@ defmodule ExOauth2Provider.AuthorizationTest do
     {:ok, %{resource_owner: user, application: application}}
   end
 
-  test "#preauthorize/2 error when missing response_type", %{resource_owner: resource_owner} do
+  test "#preauthorize/3 error when missing response_type", %{resource_owner: resource_owner} do
     params = Map.delete(@valid_request, "response_type")
 
-    assert Authorization.preauthorize(resource_owner, params) == {:error, @invalid_request, :bad_request}
+    assert Authorization.preauthorize(resource_owner, params, otp_app: :ex_oauth2_provider) == {:error, @invalid_request, :bad_request}
   end
 
-  test "#preauthorize/2 redirect when missing response_type", %{resource_owner: resource_owner, application: application} do
+  test "#preauthorize/3 redirect when missing response_type", %{resource_owner: resource_owner, application: application} do
     QueryHelpers.change!(application, redirect_uri: "#{application.redirect_uri}\nhttps://example.com/path")
 
     params = @valid_request
              |> Map.delete("response_type")
              |> Map.merge(%{"redirect_uri" => "https://example.com/path?param=1", "state" => 40_612})
 
-    assert Authorization.preauthorize(resource_owner, params) == {:redirect, "https://example.com/path?error=invalid_request&error_description=The+request+is+missing+a+required+parameter%2C+includes+an+unsupported+parameter+value%2C+or+is+otherwise+malformed.&param=1&state=40612"}
+    assert Authorization.preauthorize(resource_owner, params, otp_app: :ex_oauth2_provider) == {:redirect, "https://example.com/path?error=invalid_request&error_description=The+request+is+missing+a+required+parameter%2C+includes+an+unsupported+parameter+value%2C+or+is+otherwise+malformed.&param=1&state=40612"}
   end
 
-  test "#preauthorize/2 error when unsupported response type", %{resource_owner: resource_owner} do
+  test "#preauthorize/3 error when unsupported response type", %{resource_owner: resource_owner} do
     params = Map.merge(@valid_request, %{"response_type" => "invalid"})
 
-    assert Authorization.preauthorize(resource_owner, params) == {:error, @invalid_response_type, :unprocessable_entity}
+    assert Authorization.preauthorize(resource_owner, params, otp_app: :ex_oauth2_provider) == {:error, @invalid_response_type, :unprocessable_entity}
   end
 
-  test "#preauthorize/2 redirect when unsupported response_type", %{resource_owner: resource_owner, application: application} do
+  test "#preauthorize/3 redirect when unsupported response_type", %{resource_owner: resource_owner, application: application} do
     QueryHelpers.change!(application, redirect_uri: "#{application.redirect_uri}\nhttps://example.com/path")
 
     params = @valid_request
              |> Map.merge(%{"response_type" => "invalid"})
              |> Map.merge(%{"redirect_uri" => "https://example.com/path?param=1", "state" => 40_612})
 
-    assert Authorization.preauthorize(resource_owner, params) == {:redirect, "https://example.com/path?error=unsupported_response_type&error_description=The+authorization+server+does+not+support+this+response+type.&param=1&state=40612"}
+    assert Authorization.preauthorize(resource_owner, params, otp_app: :ex_oauth2_provider) == {:redirect, "https://example.com/path?error=unsupported_response_type&error_description=The+authorization+server+does+not+support+this+response+type.&param=1&state=40612"}
   end
 
-  test "#authorize/2 error when missing response_type", %{resource_owner: resource_owner} do
+  test "#authorize/3 error when missing response_type", %{resource_owner: resource_owner} do
     params = Map.delete(@valid_request, "response_type")
 
-    assert Authorization.authorize(resource_owner, params) == {:error, @invalid_request, :bad_request}
+    assert Authorization.authorize(resource_owner, params, otp_app: :ex_oauth2_provider) == {:error, @invalid_request, :bad_request}
   end
 
-  test "#authorize/2 rejects when unsupported response type", %{resource_owner: resource_owner} do
+  test "#authorize/3 rejects when unsupported response type", %{resource_owner: resource_owner} do
     params = Map.merge(@valid_request, %{"response_type" => "invalid"})
 
-    assert Authorization.authorize(resource_owner, params) == {:error, @invalid_response_type, :unprocessable_entity}
+    assert Authorization.authorize(resource_owner, params, otp_app: :ex_oauth2_provider) == {:error, @invalid_response_type, :unprocessable_entity}
   end
 
-  test "#deny/2 error when missing response_type", %{resource_owner: resource_owner} do
+  test "#deny/3 error when missing response_type", %{resource_owner: resource_owner} do
     params = Map.delete(@valid_request, "response_type")
 
-    assert Authorization.deny(resource_owner, params) == {:error, @invalid_request, :bad_request}
+    assert Authorization.deny(resource_owner, params, otp_app: :ex_oauth2_provider) == {:error, @invalid_request, :bad_request}
   end
 
-  test "#deny/2 rejects when unsupported response type", %{resource_owner: resource_owner} do
+  test "#deny/3 rejects when unsupported response type", %{resource_owner: resource_owner} do
     params = Map.merge(@valid_request, %{"response_type" => "invalid"})
 
-    assert Authorization.deny(resource_owner, params) == {:error, @invalid_response_type, :unprocessable_entity}
+    assert Authorization.deny(resource_owner, params, otp_app: :ex_oauth2_provider) == {:error, @invalid_response_type, :unprocessable_entity}
   end
 end

--- a/test/ex_oauth2_provider/oauth2/token/strategy/authorization_code_test.exs
+++ b/test/ex_oauth2_provider/oauth2/token/strategy/authorization_code_test.exs
@@ -33,23 +33,23 @@ defmodule ExOauth2Provider.Token.Strategy.AuthorizationCodeTest do
     {:ok, %{resource_owner: resource_owner, application: application, access_grant: access_grant}}
   end
 
-  test "#grant/1 returns access token", %{resource_owner: resource_owner, application: application, access_grant: access_grant} do
-    assert {:ok, body} = Token.grant(@valid_request)
+  test "#grant/2 returns access token", %{resource_owner: resource_owner, application: application, access_grant: access_grant} do
+    assert {:ok, body} = Token.grant(@valid_request, otp_app: :ex_oauth2_provider)
     access_token = QueryHelpers.get_latest_inserted(OauthAccessToken)
 
     assert body.access_token == access_token.token
     assert access_token.resource_owner_id == resource_owner.id
     assert access_token.application_id == application.id
     assert access_token.scopes == access_grant.scopes
-    assert access_token.expires_in == Config.access_token_expires_in([])
+    assert access_token.expires_in == Config.access_token_expires_in(otp_app: :ex_oauth2_provider)
     refute is_nil(access_token.refresh_token)
   end
 
-  test "#grant/1 returns access token when client secret not required", %{resource_owner: resource_owner, application: application} do
+  test "#grant/2 returns access token when client secret not required", %{resource_owner: resource_owner, application: application} do
     QueryHelpers.change!(application, secret: "")
     valid_request_no_client_secret = Map.drop(@valid_request, ["client_secret"])
 
-    assert {:ok, body} = Token.grant(valid_request_no_client_secret)
+    assert {:ok, body} = Token.grant(valid_request_no_client_secret, otp_app: :ex_oauth2_provider)
     access_token = QueryHelpers.get_latest_inserted(OauthAccessToken)
 
     assert body.access_token == access_token.token
@@ -57,83 +57,83 @@ defmodule ExOauth2Provider.Token.Strategy.AuthorizationCodeTest do
     assert access_token.application_id == application.id
   end
 
-  test "#grant/1 returns access token with custom response handler" do
-    assert {:ok, body} = AuthorizationCode.grant(@valid_request, access_token_response_body_handler: {__MODULE__, :access_token_response_body_handler})
+  test "#grant/2 returns access token with custom response handler" do
+    assert {:ok, body} = AuthorizationCode.grant(@valid_request, otp_app: :ex_oauth2_provider, access_token_response_body_handler: {__MODULE__, :access_token_response_body_handler})
     access_token = QueryHelpers.get_latest_inserted(OauthAccessToken)
 
     assert body.custom_attr == access_token.inserted_at
   end
 
-  test "#grant/1 doesn't set refresh_token when ExOauth2Provider.Config.use_refresh_token? == false" do
-    assert {:ok, body} = AuthorizationCode.grant(@valid_request, use_refresh_token: false)
+  test "#grant/2 doesn't set refresh_token when ExOauth2Provider.Config.use_refresh_token? == false" do
+    assert {:ok, body} = AuthorizationCode.grant(@valid_request, otp_app: :ex_oauth2_provider, use_refresh_token: false)
     access_token = QueryHelpers.get_latest_inserted(OauthAccessToken)
 
     assert body.access_token == access_token.token
     assert is_nil(access_token.refresh_token)
   end
 
-  test "#grant/1 can't use grant twice" do
-    assert {:ok, _body} = Token.grant(@valid_request)
-    assert Token.grant(@valid_request) == {:error, @invalid_grant, :unprocessable_entity}
+  test "#grant/2 can't use grant twice" do
+    assert {:ok, _body} = Token.grant(@valid_request, otp_app: :ex_oauth2_provider)
+    assert Token.grant(@valid_request, otp_app: :ex_oauth2_provider) == {:error, @invalid_grant, :unprocessable_entity}
   end
 
-  test "#grant/1 doesn't duplicate access token", %{resource_owner: resource_owner, application: application} do
-    assert {:ok, body} = Token.grant(@valid_request)
+  test "#grant/2 doesn't duplicate access token", %{resource_owner: resource_owner, application: application} do
+    assert {:ok, body} = Token.grant(@valid_request, otp_app: :ex_oauth2_provider)
     access_grant = Fixtures.access_grant(application, resource_owner, "new_code", @redirect_uri)
     valid_request = Map.merge(@valid_request, %{"code" => access_grant.token})
-    assert {:ok, body2} = Token.grant(valid_request)
+    assert {:ok, body2} = Token.grant(valid_request, otp_app: :ex_oauth2_provider)
 
     assert body.access_token == body2.access_token
   end
 
-  test "#grant/1 error when invalid client" do
+  test "#grant/2 error when invalid client" do
     request_invalid_client = Map.merge(@valid_request, %{"client_id" => "invalid"})
 
-    assert Token.grant(request_invalid_client) == {:error, @invalid_client_error, :unprocessable_entity}
+    assert Token.grant(request_invalid_client, otp_app: :ex_oauth2_provider) == {:error, @invalid_client_error, :unprocessable_entity}
   end
 
-  test "#grant/1 error when invalid secret" do
+  test "#grant/2 error when invalid secret" do
     request_invalid_client = Map.merge(@valid_request, %{"client_secret" => "invalid"})
 
-    assert Token.grant(request_invalid_client) == {:error, @invalid_client_error, :unprocessable_entity}
+    assert Token.grant(request_invalid_client, otp_app: :ex_oauth2_provider) == {:error, @invalid_client_error, :unprocessable_entity}
   end
 
-  test "#grant/1 error when invalid grant" do
+  test "#grant/2 error when invalid grant" do
     request_invalid_grant = Map.merge(@valid_request, %{"code" => "invalid"})
 
-    assert Token.grant(request_invalid_grant) == {:error, @invalid_grant, :unprocessable_entity}
+    assert Token.grant(request_invalid_grant, otp_app: :ex_oauth2_provider) == {:error, @invalid_grant, :unprocessable_entity}
   end
 
-  test "#grant/1 error when grant owned by another client", %{access_grant: access_grant} do
+  test "#grant/2 error when grant owned by another client", %{access_grant: access_grant} do
     new_application = Fixtures.application(uid: "new_app")
     QueryHelpers.change!(access_grant, application_id: new_application.id)
 
-    assert Token.grant(@valid_request) == {:error, @invalid_grant, :unprocessable_entity}
+    assert Token.grant(@valid_request, otp_app: :ex_oauth2_provider) == {:error, @invalid_grant, :unprocessable_entity}
   end
 
-  test "#grant/1 error when revoked grant", %{access_grant: access_grant} do
+  test "#grant/2 error when revoked grant", %{access_grant: access_grant} do
     QueryHelpers.change!(access_grant, revoked_at: DateTime.utc_now())
 
-    assert Token.grant(@valid_request) == {:error, @invalid_grant, :unprocessable_entity}
+    assert Token.grant(@valid_request, otp_app: :ex_oauth2_provider) == {:error, @invalid_grant, :unprocessable_entity}
   end
 
-  test "#grant/1 error when grant expired", %{access_grant: access_grant} do
+  test "#grant/2 error when grant expired", %{access_grant: access_grant} do
     inserted_at = QueryHelpers.timestamp(OauthAccessToken, :inserted_at, seconds: -access_grant.expires_in)
     QueryHelpers.change!(access_grant, inserted_at: inserted_at)
 
-    assert Token.grant(@valid_request) == {:error, @invalid_grant, :unprocessable_entity}
+    assert Token.grant(@valid_request, otp_app: :ex_oauth2_provider) == {:error, @invalid_grant, :unprocessable_entity}
   end
 
-  test "#grant/1 error when grant revoked", %{access_grant: access_grant} do
-    AccessGrants.revoke(access_grant)
+  test "#grant/2 error when grant revoked", %{access_grant: access_grant} do
+    AccessGrants.revoke(access_grant, otp_app: :ex_oauth2_provider)
 
-    assert Token.grant(@valid_request) == {:error, @invalid_grant, :unprocessable_entity}
+    assert Token.grant(@valid_request, otp_app: :ex_oauth2_provider) == {:error, @invalid_grant, :unprocessable_entity}
   end
 
-  test "#grant/1 error when invalid redirect_uri" do
+  test "#grant/2 error when invalid redirect_uri" do
     request_invalid_redirect_uri = Map.merge(@valid_request, %{"redirect_uri" => "invalid"})
 
-    assert Token.grant(request_invalid_redirect_uri) == {:error, @invalid_grant, :unprocessable_entity}
+    assert Token.grant(request_invalid_redirect_uri, otp_app: :ex_oauth2_provider) == {:error, @invalid_grant, :unprocessable_entity}
   end
 
   def access_token_response_body_handler(body, access_token) do

--- a/test/ex_oauth2_provider/oauth2/token/strategy/client_credentials_test.exs
+++ b/test/ex_oauth2_provider/oauth2/token/strategy/client_credentials_test.exs
@@ -20,27 +20,27 @@ defmodule ExOauth2Provider.Token.Strategy.ClientCredentialsTest do
     {:ok, %{application: application}}
   end
 
-  test "#grant/1 error when invalid client" do
+  test "#grant/2 error when invalid client" do
     request_invalid_client = Map.merge(@valid_request, %{"client_id" => "invalid"})
 
-    assert Token.grant(request_invalid_client) == {:error, @invalid_client_error, :unprocessable_entity}
+    assert Token.grant(request_invalid_client, otp_app: :ex_oauth2_provider) == {:error, @invalid_client_error, :unprocessable_entity}
   end
 
-  test "#grant/1 error when invalid secret" do
+  test "#grant/2 error when invalid secret" do
     request_invalid_client = Map.merge(@valid_request, %{"client_secret" => "invalid"})
 
-    assert Token.grant(request_invalid_client) == {:error, @invalid_client_error, :unprocessable_entity}
+    assert Token.grant(request_invalid_client, otp_app: :ex_oauth2_provider) == {:error, @invalid_client_error, :unprocessable_entity}
   end
 
-  test "#grant/1 returns access token", %{application: application} do
-    assert {:ok, body} = Token.grant(@valid_request)
+  test "#grant/2 returns access token", %{application: application} do
+    assert {:ok, body} = Token.grant(@valid_request, otp_app: :ex_oauth2_provider)
     access_token = QueryHelpers.get_latest_inserted(OauthAccessToken)
 
     assert body.access_token == access_token.token
     assert is_nil(access_token.resource_owner_id)
     assert access_token.application_id == application.id
     assert access_token.scopes == "app:read"
-    assert access_token.expires_in == Config.access_token_expires_in([])
+    assert access_token.expires_in == Config.access_token_expires_in(otp_app: :ex_oauth2_provider)
 
     # MUST NOT have refresh token
     assert access_token.refresh_token == nil

--- a/test/ex_oauth2_provider/oauth2/token/strategy/refresh_token_test.exs
+++ b/test/ex_oauth2_provider/oauth2/token/strategy/refresh_token_test.exs
@@ -26,45 +26,45 @@ defmodule ExOauth2Provider.Token.Strategy.RefreshTokenTest do
     {:ok, %{access_token: access_token, valid_request: valid_request}}
   end
 
-  test "#grant/1 error when invalid client", %{valid_request: valid_request} do
+  test "#grant/2 error when invalid client", %{valid_request: valid_request} do
     request_invalid_client = Map.merge(valid_request, %{"client_id" => "invalid"})
 
-    assert Token.grant(request_invalid_client) == {:error, @invalid_client_error, :unprocessable_entity}
+    assert Token.grant(request_invalid_client, otp_app: :ex_oauth2_provider) == {:error, @invalid_client_error, :unprocessable_entity}
   end
 
-  test "#grant/1 error when invalid secret", %{valid_request: valid_request} do
+  test "#grant/2 error when invalid secret", %{valid_request: valid_request} do
     request_invalid_client = Map.merge(valid_request, %{"client_secret" => "invalid"})
 
-    assert Token.grant(request_invalid_client) == {:error, @invalid_client_error, :unprocessable_entity}
+    assert Token.grant(request_invalid_client, otp_app: :ex_oauth2_provider) == {:error, @invalid_client_error, :unprocessable_entity}
   end
 
-  test "#grant/1 error when missing token", %{valid_request: valid_request} do
+  test "#grant/2 error when missing token", %{valid_request: valid_request} do
     params = Map.delete(valid_request, "refresh_token")
 
-    assert Token.grant(params) == {:error, @invalid_request_error, :bad_request}
+    assert Token.grant(params, otp_app: :ex_oauth2_provider) == {:error, @invalid_request_error, :bad_request}
   end
 
-  test "#grant/1 error when invalid token", %{valid_request: valid_request} do
+  test "#grant/2 error when invalid token", %{valid_request: valid_request} do
     params = Map.merge(valid_request, %{"refresh_token" => "invalid"})
 
-    assert Token.grant(params) == {:error, @invalid_request_error, :bad_request}
+    assert Token.grant(params, otp_app: :ex_oauth2_provider) == {:error, @invalid_request_error, :bad_request}
   end
 
-  test "#grant/1 error when access token owned by another client", %{valid_request: valid_request, access_token: access_token} do
+  test "#grant/2 error when access token owned by another client", %{valid_request: valid_request, access_token: access_token} do
     new_application = Fixtures.application(uid: "new_app")
     QueryHelpers.change!(access_token, application_id: new_application.id)
 
-    assert Token.grant(valid_request) == {:error, @invalid_request_error, :bad_request}
+    assert Token.grant(valid_request, otp_app: :ex_oauth2_provider) == {:error, @invalid_request_error, :bad_request}
   end
 
-  test "#grant/1 error when access token has been revoked", %{valid_request: valid_request, access_token: access_token} do
+  test "#grant/2 error when access token has been revoked", %{valid_request: valid_request, access_token: access_token} do
     QueryHelpers.change!(access_token, revoked_at: DateTime.utc_now())
 
-    assert Token.grant(valid_request) == {:error, @invalid_request_error, :bad_request}
+    assert Token.grant(valid_request, otp_app: :ex_oauth2_provider) == {:error, @invalid_request_error, :bad_request}
   end
 
-  test "#grant/1 returns access token", %{valid_request: valid_request, access_token: access_token} do
-    assert {:ok, new_access_token} = Token.grant(valid_request)
+  test "#grant/2 returns access token", %{valid_request: valid_request, access_token: access_token} do
+    assert {:ok, new_access_token} = Token.grant(valid_request, otp_app: :ex_oauth2_provider)
 
     access_token = Repo.get_by(OauthAccessToken, id: access_token.id)
     new_access_token = Repo.get_by(OauthAccessToken, token: new_access_token.access_token)
@@ -73,19 +73,19 @@ defmodule ExOauth2Provider.Token.Strategy.RefreshTokenTest do
     assert new_access_token.resource_owner_id == access_token.resource_owner_id
     assert new_access_token.application_id == access_token.application_id
     assert new_access_token.scopes == access_token.scopes
-    assert new_access_token.expires_in == Config.access_token_expires_in([])
+    assert new_access_token.expires_in == Config.access_token_expires_in(otp_app: :ex_oauth2_provider)
     assert new_access_token.previous_refresh_token == access_token.refresh_token
     assert AccessTokens.is_revoked?(access_token)
   end
 
-  test "#grant/1 returns access token with custom response handler", %{valid_request: valid_request} do
-    assert {:ok, body} = RefreshToken.grant(valid_request, access_token_response_body_handler: {__MODULE__, :access_token_response_body_handler})
+  test "#grant/2 returns access token with custom response handler", %{valid_request: valid_request} do
+    assert {:ok, body} = RefreshToken.grant(valid_request, otp_app: :ex_oauth2_provider, access_token_response_body_handler: {__MODULE__, :access_token_response_body_handler})
     access_token = Repo.get_by(OauthAccessToken, token: body.access_token)
     assert body.custom_attr == access_token.inserted_at
   end
 
-  test "#grant/1 when refresh_token_revoked_on_use? == false", %{valid_request: valid_request, access_token: access_token} do
-    assert {:ok, new_access_token} = RefreshToken.grant(valid_request, revoke_refresh_token_on_use: false)
+  test "#grant/2 when refresh_token_revoked_on_use? == false", %{valid_request: valid_request, access_token: access_token} do
+    assert {:ok, new_access_token} = RefreshToken.grant(valid_request, otp_app: :ex_oauth2_provider, revoke_refresh_token_on_use: false)
 
     access_token = Repo.get_by(OauthAccessToken, id: access_token.id)
     new_access_token = Repo.get_by(OauthAccessToken, token: new_access_token.access_token)

--- a/test/ex_oauth2_provider/oauth2/token/strategy/revoke_test.exs
+++ b/test/ex_oauth2_provider/oauth2/token/strategy/revoke_test.exs
@@ -22,51 +22,51 @@ defmodule ExOauth2Provider.Token.Strategy.RevokeTest do
     {:ok, %{access_token: access_token, valid_request: valid_request}}
   end
 
-  test "#revoke/1 error when invalid client", %{valid_request: valid_request} do
+  test "#revoke/2 error when invalid client", %{valid_request: valid_request} do
     params = Map.merge(valid_request, %{"client_id" => "invalid"})
 
-    assert Token.revoke(params) == {:error, @invalid_client_error, :unprocessable_entity}
+    assert Token.revoke(params, otp_app: :ex_oauth2_provider) == {:error, @invalid_client_error, :unprocessable_entity}
   end
 
-  test "#revoke/1 error when invalid secret", %{valid_request: valid_request} do
+  test "#revoke/2 error when invalid secret", %{valid_request: valid_request} do
     params = Map.merge(valid_request, %{"client_secret" => "invalid"})
 
-    assert Token.revoke(params) == {:error, @invalid_client_error, :unprocessable_entity}
+    assert Token.revoke(params, otp_app: :ex_oauth2_provider) == {:error, @invalid_client_error, :unprocessable_entity}
   end
 
-  test "#revoke/1 when missing token", %{valid_request: valid_request} do
+  test "#revoke/2 when missing token", %{valid_request: valid_request} do
     params = Map.delete(valid_request, "token")
 
-    assert Token.revoke(params) == {:ok, %{}}
+    assert Token.revoke(params, otp_app: :ex_oauth2_provider) == {:ok, %{}}
     refute AccessTokens.is_revoked?(QueryHelpers.get_latest_inserted(OauthAccessToken))
   end
 
-  test "#revoke/1 when invalid token", %{valid_request: valid_request} do
+  test "#revoke/2 when invalid token", %{valid_request: valid_request} do
     params = Map.merge(valid_request, %{"token" => "invalid"})
 
-    assert Token.revoke(params) == {:ok, %{}}
+    assert Token.revoke(params, otp_app: :ex_oauth2_provider) == {:ok, %{}}
     refute AccessTokens.is_revoked?(QueryHelpers.get_latest_inserted(OauthAccessToken))
   end
 
-  test "#revoke/1 when access token owned by another client", %{valid_request: valid_request, access_token: access_token} do
+  test "#revoke/2 when access token owned by another client", %{valid_request: valid_request, access_token: access_token} do
     new_application = Fixtures.application(uid: "new_app", client_secret: "new")
     QueryHelpers.change!(access_token, application_id: new_application.id)
 
-    assert Token.revoke(valid_request) == {:ok, %{}}
+    assert Token.revoke(valid_request, otp_app: :ex_oauth2_provider) == {:ok, %{}}
     refute AccessTokens.is_revoked?(QueryHelpers.get_latest_inserted(OauthAccessToken))
   end
 
-  test "#revoke/1 when access token not owned by a client", %{access_token: access_token} do
+  test "#revoke/2 when access token not owned by a client", %{access_token: access_token} do
     QueryHelpers.change!(access_token, application_id: nil)
 
     params = %{"token" => access_token.token}
 
-    assert Token.revoke(params) == {:ok, %{}}
+    assert Token.revoke(params, otp_app: :ex_oauth2_provider) == {:ok, %{}}
     assert AccessTokens.is_revoked?(QueryHelpers.get_latest_inserted(OauthAccessToken))
   end
 
-  test "#revoke/1", %{valid_request: valid_request} do
-    assert Token.revoke(valid_request) == {:ok, %{}}
+  test "#revoke/2", %{valid_request: valid_request} do
+    assert Token.revoke(valid_request, otp_app: :ex_oauth2_provider) == {:ok, %{}}
     assert AccessTokens.is_revoked?(QueryHelpers.get_latest_inserted(OauthAccessToken))
   end
 end

--- a/test/ex_oauth2_provider/oauth2/token_test.exs
+++ b/test/ex_oauth2_provider/oauth2/token_test.exs
@@ -12,7 +12,7 @@ defmodule ExOauth2Provider.TokenTest do
     {:ok, %{application: application}}
   end
 
-  test "#grant/1 error when invalid grant_type" do
+  test "#grant/2 error when invalid grant_type" do
     request_invalid_grant_type = Map.merge(%{"client_id" => @client_id,
                                              "client_secret" => @client_secret,
                                              "grant_type" => "client_credentials"},
@@ -20,6 +20,6 @@ defmodule ExOauth2Provider.TokenTest do
     expected_error = %{error: :unsupported_grant_type,
                        error_description: "The authorization grant type is not supported by the authorization server."}
 
-    assert Token.grant(request_invalid_grant_type) == {:error, expected_error, :unprocessable_entity}
+    assert Token.grant(request_invalid_grant_type, otp_app: :ex_oauth2_provider) == {:error, expected_error, :unprocessable_entity}
   end
 end

--- a/test/ex_oauth2_provider/plug/verify_header_test.exs
+++ b/test/ex_oauth2_provider/plug/verify_header_test.exs
@@ -7,7 +7,7 @@ defmodule ExOauth2Provider.Plug.VerifyHeaderTest do
   alias ExOauth2Provider.Test.Fixtures
 
   test "with no access token at a default location", %{conn: conn} do
-    opts = VerifyHeader.init([])
+    opts = VerifyHeader.init(otp_app: :ex_oauth2_provider)
     conn = VerifyHeader.call(conn, opts)
 
     refute Plug.authenticated?(conn)
@@ -15,7 +15,7 @@ defmodule ExOauth2Provider.Plug.VerifyHeaderTest do
   end
 
   test "with no access token at a specified location", %{conn: conn} do
-    opts = VerifyHeader.init(key: :secret)
+    opts = VerifyHeader.init(otp_app: :ex_oauth2_provider, key: :secret)
     conn = VerifyHeader.call(conn, opts)
 
     refute Plug.authenticated?(conn, :secret)
@@ -30,7 +30,7 @@ defmodule ExOauth2Provider.Plug.VerifyHeaderTest do
     end
 
     test "at the default location", %{conn: conn, access_token: access_token} do
-      opts = VerifyHeader.init()
+      opts = VerifyHeader.init(otp_app: :ex_oauth2_provider)
       conn =
         conn
         |> Conn.put_req_header("authorization", access_token.token)
@@ -41,7 +41,7 @@ defmodule ExOauth2Provider.Plug.VerifyHeaderTest do
     end
 
     test "at a specified location", %{conn: conn, access_token: access_token} do
-      opts = VerifyHeader.init(key: :secret)
+      opts = VerifyHeader.init(otp_app: :ex_oauth2_provider, key: :secret)
       conn =
         conn
         |> Conn.put_req_header("authorization", access_token.token)
@@ -52,7 +52,7 @@ defmodule ExOauth2Provider.Plug.VerifyHeaderTest do
     end
 
     test "with a realm specified", %{conn: conn, access_token: access_token} do
-      opts = VerifyHeader.init(realm: "Bearer")
+      opts = VerifyHeader.init(otp_app: :ex_oauth2_provider, realm: "Bearer")
       conn =
         conn
         |> Conn.put_req_header("authorization", "Bearer #{access_token.token}")
@@ -65,7 +65,7 @@ defmodule ExOauth2Provider.Plug.VerifyHeaderTest do
     test "with a realm specified and multiple auth headers", %{conn: conn, access_token: access_token} do
       another_access_token = Fixtures.access_token()
 
-      opts = VerifyHeader.init(realm: "Client")
+      opts = VerifyHeader.init(otp_app: :ex_oauth2_provider, realm: "Client")
       conn =
         conn
         |> Conn.put_req_header("authorization", "Bearer #{access_token.token}")
@@ -84,8 +84,8 @@ defmodule ExOauth2Provider.Plug.VerifyHeaderTest do
         {"authorization", "Client #{another_access_token.token}"}
       ]
 
-      opts_1 = VerifyHeader.init(realm: "Bearer")
-      opts_2 = VerifyHeader.init(realm: "Client", key: :client)
+      opts_1 = VerifyHeader.init(otp_app: :ex_oauth2_provider, realm: "Bearer")
+      opts_2 = VerifyHeader.init(otp_app: :ex_oauth2_provider, realm: "Client", key: :client)
       conn =
         conn
         |> Map.put(:req_headers, req_headers)

--- a/test/ex_oauth2_provider/redirect_uri_test.exs
+++ b/test/ex_oauth2_provider/redirect_uri_test.exs
@@ -3,7 +3,7 @@ defmodule ExOauth2Provider.RedirectURITest do
   alias ExOauth2Provider.{Config, RedirectURI}
 
   test "validate native url" do
-    uri = Config.native_redirect_uri([])
+    uri = Config.native_redirect_uri(otp_app: :ex_oauth2_provider)
     assert RedirectURI.validate(uri, []) == {:ok, uri}
   end
 

--- a/test/ex_oauth2_provider_test.exs
+++ b/test/ex_oauth2_provider_test.exs
@@ -6,15 +6,15 @@ defmodule ExOauth2ProviderTest do
   alias ExOauth2Provider.Test.Fixtures
   alias Dummy.{OauthAccessTokens.OauthAccessToken, Repo}
 
-  describe "authenticate_token/1" do
+  describe "authenticate_token/2" do
     test "error when invalid" do
-      assert ExOauth2Provider.authenticate_token(nil) == {:error, :token_inaccessible}
-      assert ExOauth2Provider.authenticate_token("secret") == {:error, :token_not_found}
+      assert ExOauth2Provider.authenticate_token(nil, otp_app: :ex_oauth2_provider) == {:error, :token_inaccessible}
+      assert ExOauth2Provider.authenticate_token("secret", otp_app: :ex_oauth2_provider) == {:error, :token_not_found}
     end
 
     test "authenticates" do
       access_token = Fixtures.access_token()
-      assert ExOauth2Provider.authenticate_token(access_token.token) == {:ok, access_token}
+      assert ExOauth2Provider.authenticate_token(access_token.token, otp_app: :ex_oauth2_provider) == {:ok, access_token}
       assert access_token.resource_owner
     end
 
@@ -22,7 +22,7 @@ defmodule ExOauth2ProviderTest do
       application = Fixtures.application()
       access_token = Fixtures.application_access_token(application: application)
 
-      assert {:ok, access_token} = ExOauth2Provider.authenticate_token(access_token.token)
+      assert {:ok, access_token} = ExOauth2Provider.authenticate_token(access_token.token, otp_app: :ex_oauth2_provider)
       refute access_token.resource_owner
     end
 
@@ -31,13 +31,13 @@ defmodule ExOauth2ProviderTest do
       access_token  = Fixtures.access_token(resource_owner: user, use_refresh_token: true)
       access_token2 = Fixtures.access_token(resource_owner: user, use_refresh_token: true, previous_refresh_token: access_token)
 
-      assert {:ok, access_token} = ExOauth2Provider.authenticate_token(access_token.token)
+      assert {:ok, access_token} = ExOauth2Provider.authenticate_token(access_token.token, otp_app: :ex_oauth2_provider)
       access_token = Repo.get_by(OauthAccessToken, token: access_token.token)
       refute AccessTokens.is_revoked?(access_token)
       access_token2 = Repo.get_by(OauthAccessToken, token: access_token2.token)
       refute "" == access_token2.previous_refresh_token
 
-      assert {:ok, access_token2} = ExOauth2Provider.authenticate_token(access_token2.token)
+      assert {:ok, access_token2} = ExOauth2Provider.authenticate_token(access_token2.token, otp_app: :ex_oauth2_provider)
       access_token = Repo.get_by(OauthAccessToken, token: access_token.token)
       assert AccessTokens.is_revoked?(access_token)
       access_token2 = Repo.get_by(OauthAccessToken, token: access_token2.token)
@@ -49,7 +49,7 @@ defmodule ExOauth2ProviderTest do
       access_token  = Fixtures.access_token(resource_owner: user, use_refresh_token: true)
       access_token2 = Fixtures.access_token(resource_owner: user, use_refresh_token: true, previous_refresh_token: access_token)
 
-      assert {:ok, access_token2} = ExOauth2Provider.authenticate_token(access_token2.token, revoke_refresh_token_on_use: false)
+      assert {:ok, access_token2} = ExOauth2Provider.authenticate_token(access_token2.token, otp_app: :ex_oauth2_provider, revoke_refresh_token_on_use: false)
       access_token = Repo.get_by(OauthAccessToken, token: access_token.token)
       refute AccessTokens.is_revoked?(access_token)
       access_token2 = Repo.get_by(OauthAccessToken, token: access_token2.token)
@@ -59,14 +59,14 @@ defmodule ExOauth2ProviderTest do
     test "error when expired token" do
       access_token = Fixtures.access_token(expires_in: -1)
 
-      assert ExOauth2Provider.authenticate_token(access_token.token) == {:error, :token_inaccessible}
+      assert ExOauth2Provider.authenticate_token(access_token.token, otp_app: :ex_oauth2_provider) == {:error, :token_inaccessible}
     end
 
     test "error when revoked token" do
       access_token = Fixtures.access_token()
       AccessTokens.revoke(access_token)
 
-      assert ExOauth2Provider.authenticate_token(access_token.token) == {:error, :token_inaccessible}
+      assert ExOauth2Provider.authenticate_token(access_token.token, otp_app: :ex_oauth2_provider) == {:error, :token_inaccessible}
     end
   end
 end

--- a/test/mix/tasks/ex_oauth2_provider.gen.schemas_test.exs
+++ b/test/mix/tasks/ex_oauth2_provider.gen.schemas_test.exs
@@ -30,7 +30,7 @@ defmodule Mix.Tasks.ExOauth2Provider.Gen.SchemasTest do
         content = File.read!(path)
 
         assert content =~ "defmodule #{inspect module} do"
-        assert content =~ "use #{inspect macro}"
+        assert content =~ "use #{inspect macro}, otp_app: :test"
         assert content =~ "schema \"oauth_#{file}s\" do"
         assert content =~ "#{file}_fields()"
       end

--- a/test/support/fixtures.ex
+++ b/test/support/fixtures.ex
@@ -36,7 +36,7 @@ defmodule ExOauth2Provider.Test.Fixtures do
       attrs
       |> Keyword.get(:resource_owner)
       |> Kernel.||(resource_owner())
-      |> AccessTokens.create_token(Enum.into(attrs, %{}))
+      |> AccessTokens.create_token(Enum.into(attrs, %{}), otp_app: :ex_oauth2_provider)
 
     access_token
   end
@@ -46,7 +46,7 @@ defmodule ExOauth2Provider.Test.Fixtures do
       attrs
       |> Keyword.get(:application)
       |> Kernel.||(application())
-      |> AccessTokens.create_application_token(Enum.into(attrs, %{}))
+      |> AccessTokens.create_application_token(Enum.into(attrs, %{}), otp_app: :ex_oauth2_provider)
 
     access_token
   end

--- a/test/support/lib/dummy/oauth_access_grants/oauth_access_grant.ex
+++ b/test/support/lib/dummy/oauth_access_grants/oauth_access_grant.ex
@@ -1,6 +1,6 @@
 defmodule Dummy.OauthAccessGrants.OauthAccessGrant do
   use Ecto.Schema
-  use ExOauth2Provider.AccessGrants.AccessGrant
+  use ExOauth2Provider.AccessGrants.AccessGrant, otp_app: :ex_oauth2_provider
 
   if System.get_env("UUID") do
     @primary_key {:id, :binary_id, autogenerate: true}

--- a/test/support/lib/dummy/oauth_access_tokens/oauth_access_token.ex
+++ b/test/support/lib/dummy/oauth_access_tokens/oauth_access_token.ex
@@ -1,6 +1,6 @@
 defmodule Dummy.OauthAccessTokens.OauthAccessToken do
   use Ecto.Schema
-  use ExOauth2Provider.AccessTokens.AccessToken
+  use ExOauth2Provider.AccessTokens.AccessToken, otp_app: :ex_oauth2_provider
 
   if System.get_env("UUID") do
     @primary_key {:id, :binary_id, autogenerate: true}

--- a/test/support/lib/dummy/oauth_applications/oauth_application.ex
+++ b/test/support/lib/dummy/oauth_applications/oauth_application.ex
@@ -1,6 +1,6 @@
 defmodule Dummy.OauthApplications.OauthApplication do
   use Ecto.Schema
-  use ExOauth2Provider.Applications.Application
+  use ExOauth2Provider.Applications.Application, otp_app: :ex_oauth2_provider
 
   if System.get_env("UUID") do
     @primary_key {:id, :binary_id, autogenerate: true}


### PR DESCRIPTION
This is a larger rewrite to ensure that otp_app is defined on compile time. Releases doesn't include `:app` key.