### PR TITLE
Make custom redirect_uri_match_fun work with authorization validations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.5.3 (TBA)
+
+* Fixed bug in `ExOauth2Provider.RedirectURI.valid_for_authorization?/3` where the `:redirect_uri_match_fun` configuration option was not used
+* Deprecated `ExOauth2Provider.RedirectURI.matches?/2`
+
 ## v0.5.2 (2019-06-10)
 
 * Added `:redirect_uri_match_fun` configuration option for custom matching of redirect uri

--- a/lib/ex_oauth2_provider/redirect_uri.ex
+++ b/lib/ex_oauth2_provider/redirect_uri.ex
@@ -40,11 +40,14 @@ defmodule ExOauth2Provider.RedirectURI do
     Config.force_ssl_in_redirect_uri?(config) and uri.scheme == "http"
   end
 
+  @doc false
+  @deprecated "Use `matches?/3` instead"
+  def matches?(uri, client_uri), do: matches?(uri, client_uri, [])
+
   @doc """
   Check if uri matches client uri
   """
   @spec matches?(binary(), binary(), keyword()) :: boolean()
-  def matches?(uri, client_uri, config \\ [])
   def matches?(uri, client_uri, config) when is_binary(uri) and is_binary(client_uri) do
     matches?(URI.parse(uri), URI.parse(client_uri), config)
   end

--- a/lib/ex_oauth2_provider/redirect_uri.ex
+++ b/lib/ex_oauth2_provider/redirect_uri.ex
@@ -63,14 +63,14 @@ defmodule ExOauth2Provider.RedirectURI do
   def valid_for_authorization?(url, client_url, config) do
     url
     |> validate(config)
-    |> do_valid_for_authorization?(client_url)
+    |> do_valid_for_authorization?(client_url, config)
   end
 
-  defp do_valid_for_authorization?({:error, _error}, _client_url), do: false
-  defp do_valid_for_authorization?({:ok, url}, client_url) do
+  defp do_valid_for_authorization?({:error, _error}, _client_url, _config), do: false
+  defp do_valid_for_authorization?({:ok, url}, client_url, config) do
     client_url
     |> String.split()
-    |> Enum.any?(&matches?(url, &1))
+    |> Enum.any?(&matches?(url, &1, config))
   end
 
   @doc """

--- a/test/ex_oauth2_provider/redirect_uri_test.exs
+++ b/test/ex_oauth2_provider/redirect_uri_test.exs
@@ -78,23 +78,6 @@ defmodule ExOauth2Provider.RedirectURITest do
     assert RedirectURI.valid_for_authorization?(uri, uri, [])
   end
 
-  test "valid_for_authorization?#true with custom match method" do
-     uri = "https://a.app.co/"
-     client_uri = "https://*.app.co/"
-
-     config = [
-       {
-         :redirect_uri_match_fun,
-         fn uri, %{host: "*." <> host} = client_uri, _config ->
-           String.ends_with?(uri.host, host) &&
-             %{uri | query: nil} == %{client_uri | host: uri.host, authority: uri.authority}
-         end
-       }
-     ]
-
-     assert RedirectURI.valid_for_authorization?(uri, client_uri, config)
-   end
-
   test "valid_for_authorization?#false" do
     refute RedirectURI.valid_for_authorization?("https://app.co/aaa", "https://app.co/bbb", [])
   end

--- a/test/ex_oauth2_provider/redirect_uri_test.exs
+++ b/test/ex_oauth2_provider/redirect_uri_test.exs
@@ -49,19 +49,28 @@ defmodule ExOauth2Provider.RedirectURITest do
 
   test "matches?#true" do
     uri = "https://app.co/aaa"
-    assert RedirectURI.matches?(uri, uri)
+    assert RedirectURI.matches?(uri, uri, [])
+  end
+
+  test "matches?#true with custom match method" do
+    uri = "https://a.app.co/"
+    client_uri = "https://*.app.co/"
+
+    assert RedirectURI.matches?(uri, client_uri, redirect_uri_match_fun: fn uri, %{host: "*." <> host} = client_uri, _config ->
+      String.ends_with?(uri.host, host) && %{uri | query: nil} == %{client_uri | host: uri.host, authority: uri.authority}
+    end)
   end
 
   test "matches?#true ignores query parameter on comparison" do
-    assert RedirectURI.matches?("https://app.co/?query=hello", "https://app.co/")
+    assert RedirectURI.matches?("https://app.co/?query=hello", "https://app.co/", [])
   end
 
   test "matches?#false" do
-    refute RedirectURI.matches?("https://app.co/?query=hello", "https://app.co")
+    refute RedirectURI.matches?("https://app.co/?query=hello", "https://app.co", [])
   end
 
   test "matches?#false with domains that doesn't start at beginning" do
-    refute RedirectURI.matches?("https://app.co/?query=hello", "https://example.com?app.co=test")
+    refute RedirectURI.matches?("https://app.co/?query=hello", "https://example.com?app.co=test", [])
   end
 
   test "valid_for_authorization?#true" do
@@ -72,7 +81,7 @@ defmodule ExOauth2Provider.RedirectURITest do
   test "valid_for_authorization?#true with custom match method" do
      uri = "https://a.app.co/"
      client_uri = "https://*.app.co/"
- 
+
      config = [
        {
          :redirect_uri_match_fun,
@@ -82,7 +91,7 @@ defmodule ExOauth2Provider.RedirectURITest do
          end
        }
      ]
- 
+
      assert RedirectURI.valid_for_authorization?(uri, client_uri, config)
    end
 

--- a/test/ex_oauth2_provider/redirect_uri_test.exs
+++ b/test/ex_oauth2_provider/redirect_uri_test.exs
@@ -52,15 +52,6 @@ defmodule ExOauth2Provider.RedirectURITest do
     assert RedirectURI.matches?(uri, uri)
   end
 
-  test "matches?#true with custom match method" do
-    uri = "https://a.app.co/"
-    client_uri = "https://*.app.co/"
-
-    assert RedirectURI.matches?(uri, client_uri, redirect_uri_match_fun: fn uri, %{host: "*." <> host} = client_uri, _config ->
-      String.ends_with?(uri.host, host) && %{uri | query: nil} == %{client_uri | host: uri.host, authority: uri.authority}
-    end)
-  end
-
   test "matches?#true ignores query parameter on comparison" do
     assert RedirectURI.matches?("https://app.co/?query=hello", "https://app.co/")
   end
@@ -77,6 +68,23 @@ defmodule ExOauth2Provider.RedirectURITest do
     uri = "https://app.co/aaa"
     assert RedirectURI.valid_for_authorization?(uri, uri, [])
   end
+
+  test "valid_for_authorization?#true with custom match method" do
+     uri = "https://a.app.co/"
+     client_uri = "https://*.app.co/"
+ 
+     config = [
+       {
+         :redirect_uri_match_fun,
+         fn uri, %{host: "*." <> host} = client_uri, _config ->
+           String.ends_with?(uri.host, host) &&
+             %{uri | query: nil} == %{client_uri | host: uri.host, authority: uri.authority}
+         end
+       }
+     ]
+ 
+     assert RedirectURI.valid_for_authorization?(uri, client_uri, config)
+   end
 
   test "valid_for_authorization?#false" do
     refute RedirectURI.valid_for_authorization?("https://app.co/aaa", "https://app.co/bbb", [])


### PR DESCRIPTION
Working with @blatyo, we discovered that custom
`redirect_uri_match_fun`s were not being invoked during the
authorization phase. This fixes that by passing the config from
`RedirectURI.valid_for_authorization?` to `matches?`.