### PR TITLE
support overriding application owner with config option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.5.6 (TBA)
+
+* Permit associations to be overridden
+* Updated the documentation for how to set application resource owner
+
 ## v0.5.5 (2019-10-31)
 
 * Fixed bug where `Mix.env` is called on runtime rather than compile time

--- a/lib/ex_oauth2_provider.ex
+++ b/lib/ex_oauth2_provider.ex
@@ -6,7 +6,6 @@ defmodule ExOauth2Provider do
       config :my_app, ExOauth2Provider,
         repo: App.Repo,
         resource_owner: App.Users.User,
-        application_owner: App.Users.User,
         default_scopes: ~w(public),
         optional_scopes: ~w(write update),
         native_redirect_uri: "urn:ietf:wg:oauth:2.0:oob",

--- a/lib/ex_oauth2_provider/applications/application.ex
+++ b/lib/ex_oauth2_provider/applications/application.ex
@@ -16,6 +16,25 @@ defmodule ExOauth2Provider.Applications.Application do
           timestamps()
         end
       end
+
+  ## Application owner
+
+  By default the application owner will be will be the `:resource_owner`
+  configuration setting. You can override this by overriding the `:owner`
+  belongs to association:
+
+      defmodule MyApp.OauthApplications.OauthApplication do
+        use Ecto.Schema
+        use ExOauth2Provider.Applications.Application
+
+        schema "oauth_applications" do
+          belongs_to :owner, MyApp.Users.User
+
+          application_fields()
+
+          timestamps()
+        end
+      end
   """
 
   @type t :: Ecto.Schema.t()

--- a/lib/ex_oauth2_provider/config.ex
+++ b/lib/ex_oauth2_provider/config.ex
@@ -17,10 +17,6 @@ defmodule ExOauth2Provider.Config do
   def resource_owner(config),
     do: get(config, :resource_owner) || app_module(config, "Users", "User")
 
-  @spec application_owner(keyword()) :: module()
-  def application_owner(config),
-    do: get(config, :application_owner) || app_module(config, "Users", "User")
-
   defp app_module(config, context, module) do
     app =
       config

--- a/lib/ex_oauth2_provider/config.ex
+++ b/lib/ex_oauth2_provider/config.ex
@@ -17,6 +17,10 @@ defmodule ExOauth2Provider.Config do
   def resource_owner(config),
     do: get(config, :resource_owner) || app_module(config, "Users", "User")
 
+  @spec application_owner(keyword()) :: module()
+  def application_owner(config),
+    do: get(config, :application_owner) || app_module(config, "Users", "User")
+
   defp app_module(config, context, module) do
     app =
       config

--- a/lib/ex_oauth2_provider/schema.ex
+++ b/lib/ex_oauth2_provider/schema.ex
@@ -24,6 +24,7 @@ defmodule ExOauth2Provider.Schema do
 
       unquote(module).assocs()
       |> unquote(__MODULE__).__assocs_with_queryable__(@config)
+      |> unquote(__MODULE__).__filter_new_assocs__(@ecto_assocs)
       |> Enum.each(fn
         {:belongs_to, name, queryable} ->
           belongs_to(name, queryable)
@@ -43,8 +44,6 @@ defmodule ExOauth2Provider.Schema do
   @doc false
   def __assocs_with_queryable__(assocs, config) do
     Enum.map(assocs, fn
-      {:belongs_to, :owner, table} -> {:belongs_to, :owner, Config.application_owner(config)}
-      {:belongs_to, :owner, table, defaults} -> {:belongs_to, :owner, Config.application_owner(config), defaults}
       {:belongs_to, name, table} -> {:belongs_to, name, table_to_queryable(config, table)}
       {:belongs_to, name, table, defaults} -> {:belongs_to, name, table_to_queryable(config, table), defaults}
       {:has_many, name, table} -> {:has_many, name, table_to_queryable(config, table)}
@@ -57,14 +56,26 @@ defmodule ExOauth2Provider.Schema do
   defp table_to_queryable(config, :applications), do: Config.application(config)
   defp table_to_queryable(config, :users), do: Config.resource_owner(config)
 
-    @doc false
-    def __timestamp_for__(struct, column) do
-      type = struct.__schema__(:type, column)
+  @doc false
+  def __filter_new_assocs__(assocs, existing_assocs) do
+    Enum.reject(assocs, fn assoc ->
+      Enum.any?(existing_assocs, &assocs_match?(elem(assoc, 0), elem(assoc, 1), &1))
+    end)
+  end
 
-      __timestamp__(type)
-    end
+  defp assocs_match?(:has_many, name, {name, %Ecto.Association.Has{cardinality: :many}}), do: true
+  defp assocs_match?(:belongs_to, name, {name, %Ecto.Association.BelongsTo{}}), do: true
+  defp assocs_match?(_type, _name, _existing_assoc), do: false
 
-    @doc false
+
+  @doc false
+  def __timestamp_for__(struct, column) do
+    type = struct.__schema__(:type, column)
+
+    __timestamp__(type)
+  end
+
+  @doc false
   def __timestamp__(:naive_datetime) do
     %{NaiveDateTime.utc_now() | microsecond: {0, 0}}
   end

--- a/lib/ex_oauth2_provider/schema.ex
+++ b/lib/ex_oauth2_provider/schema.ex
@@ -43,6 +43,8 @@ defmodule ExOauth2Provider.Schema do
   @doc false
   def __assocs_with_queryable__(assocs, config) do
     Enum.map(assocs, fn
+      {:belongs_to, :owner, table} -> {:belongs_to, :owner, Config.application_owner(config)}
+      {:belongs_to, :owner, table, defaults} -> {:belongs_to, :owner, Config.application_owner(config), defaults}
       {:belongs_to, name, table} -> {:belongs_to, name, table_to_queryable(config, table)}
       {:belongs_to, name, table, defaults} -> {:belongs_to, name, table_to_queryable(config, table), defaults}
       {:has_many, name, table} -> {:has_many, name, table_to_queryable(config, table)}

--- a/test/ex_oauth2_provider/applications/application_test.exs
+++ b/test/ex_oauth2_provider/applications/application_test.exs
@@ -50,4 +50,27 @@ defmodule ExOauth2Provider.Applications.ApplicationTest do
       refute changeset.errors[:scopes]
     end
   end
+
+  defmodule OverrideOwner do
+    @moduledoc false
+
+    use Ecto.Schema
+    use ExOauth2Provider.Applications.Application, otp_app: :ex_oauth2_provider
+
+    if System.get_env("UUID") do
+      @primary_key {:id, :binary_id, autogenerate: true}
+      @foreign_key_type :binary_id
+    end
+
+    schema "oauth_applications" do
+      belongs_to :owner, __MODULE__
+
+      application_fields()
+      timestamps()
+    end
+  end
+
+  test "with overridden `:owner`" do
+    assert %Ecto.Association.BelongsTo{owner: OverrideOwner} = OverrideOwner.__schema__(:association, :owner)
+  end
 end


### PR DESCRIPTION
Currently, the application_owner config option is ignored. Referenced in docs: [https://hexdocs.pm/ex_oauth2_provider/ExOauth2Provider.html#module-configuration](url)

Issue https://github.com/danschultzer/ex_oauth2_provider/issues/67