### PR TITLE
Improve return type spec for revocation of tokens

### DIFF
--- a/lib/ex_oauth2_provider/applications/applications.ex
+++ b/lib/ex_oauth2_provider/applications/applications.ex
@@ -202,10 +202,10 @@ defmodule ExOauth2Provider.Applications do
   ## Examples
 
       iex> revoke_all_access_tokens_for(application, resource_owner, otp_app: :my_app)
-      {:ok, [%OauthAccessToken{}]}
+      {:ok, [ok: %OauthAccessToken{}]}
 
   """
-  @spec revoke_all_access_tokens_for(Application.t(), Schema.t(), keyword()) :: [AccessToken.t()]
+  @spec revoke_all_access_tokens_for(Application.t(), Schema.t(), keyword()) :: {:ok, [ok: AccessToken.t()]} | {:error, any()}
   def revoke_all_access_tokens_for(application, resource_owner, config \\ []) do
     repo = Config.repo(config)
 


### PR DESCRIPTION
`ExOauth2Provider.Applications.revoke_all_access_tokens_for/2` will return a tuple of {:ok, any()} or {:error, any()}, as a function is passed to the call to [Ecto.Repo.transaction/2](https://hexdocs.pm/ecto/3.4.6/Ecto.Repo.html#c:transaction/2). By modifying the spec, dialyzer will pass if this is handled in a case statement matching on the response with something like:

```
case ExOauth2Provider.Applications.revoke_all_access_tokens_for(application, resource_owner, config) do
  {:ok, [ok: %AccessToken{}]} -> handle_success()
  {:error, value} -> handle_error(value)
end
```