### PR TITLE
Extensible AccessGrants and AccessTokens

### DIFF
--- a/lib/ex_oauth2_provider/changeset.ex
+++ b/lib/ex_oauth2_provider/changeset.ex
@@ -1,0 +1,14 @@
+defmodule ExOauth2Provider.Changeset do
+  @moduledoc """
+  This module defines behaviour for oauth changesets
+  """
+  @callback allowed_fields() :: nonempty_list(atom())
+  @callback required_fields() :: nonempty_list(atom())
+  @callback request_fields() :: nonempty_list(binary())
+
+  defmacro __using__(_) do
+    quote do
+      @behaviour ExOauth2Provider.Changeset
+    end
+  end
+end

--- a/lib/ex_oauth2_provider/oauth2/authorization/strategy/code.ex
+++ b/lib/ex_oauth2_provider/oauth2/authorization/strategy/code.ex
@@ -142,7 +142,7 @@ defmodule ExOauth2Provider.Authorization.Code do
   defp issue_grant({:ok, %{resource_owner: resource_owner, client: application, request: request} = params}, config) do
     grant_params =
       request
-      |> Map.take(["redirect_uri", "scope"])
+      |> Map.take(Config.access_grant(config).request_fields())
       |> Map.new(fn {k, v} ->
         case k do
           "scope" -> {:scopes, v}
@@ -153,7 +153,8 @@ defmodule ExOauth2Provider.Authorization.Code do
 
     case AccessGrants.create_grant(resource_owner, application, grant_params, config) do
       {:ok, grant}    -> {:ok, Map.put(params, :grant, grant)}
-      {:error, error} -> Error.add_error({:ok, params}, error)
+      {:error, {:error, _, _} = error} -> Error.add_error({:ok, params}, error)
+      {:error, _} -> Error.add_error({:ok, params}, Error.server_error())
     end
   end
 

--- a/lib/ex_oauth2_provider/oauth2/token/strategy/authorization_code.ex
+++ b/lib/ex_oauth2_provider/oauth2/token/strategy/authorization_code.ex
@@ -75,8 +75,8 @@ defmodule ExOauth2Provider.Token.AuthorizationCode do
        ) do
     token_params =
       grant
-      |> Map.drop([:expires_in])
-      |> Map.take(Config.access_token(config).required_fields())
+      |> Map.drop([:expires_in, :scopes])
+      |> Map.take(Config.access_token(config).allowed_fields())
       |> Map.merge(token_params)
       |> Map.merge(%{scopes: scopes, application: application})
 

--- a/lib/ex_oauth2_provider/oauth2/token/strategy/authorization_code.ex
+++ b/lib/ex_oauth2_provider/oauth2/token/strategy/authorization_code.ex
@@ -37,14 +37,23 @@ defmodule ExOauth2Provider.Token.AuthorizationCode do
   end
 
   defp issue_access_token_by_grant({:error, params}, _config), do: {:error, params}
-  defp issue_access_token_by_grant({:ok, %{access_grant: access_grant, request: _} = params}, config) do
-    token_params = %{use_refresh_token: Config.use_refresh_token?(config)}
 
-    result = Config.repo(config).transaction(fn ->
-      access_grant
-      |> revoke_grant(config)
-      |> maybe_create_access_token(token_params, config)
-    end)
+  defp issue_access_token_by_grant(
+         {:ok, %{access_grant: access_grant, request: request} = params},
+         config
+       ) do
+    token_params =
+      request
+      |> Map.take(Config.access_token(config).request_fields())
+      |> Map.new(fn {k, v} -> {String.to_atom(k), v} end)
+      |> Map.put(:use_refresh_token, Config.use_refresh_token?(config))
+
+    result =
+      Config.repo(config).transaction(fn ->
+        access_grant
+        |> revoke_grant(config)
+        |> maybe_create_access_token(token_params, config)
+      end)
 
     case result do
       {:ok, {:error, error}}     -> Error.add_error({:ok, params}, error)
@@ -57,8 +66,19 @@ defmodule ExOauth2Provider.Token.AuthorizationCode do
     do: AccessGrants.revoke(access_grant, config)
 
   defp maybe_create_access_token({:error, _} = error, _token_params, _config), do: error
-  defp maybe_create_access_token({:ok, %{resource_owner: resource_owner, application: application, scopes: scopes}}, token_params, config) do
-    token_params = Map.merge(token_params, %{scopes: scopes, application: application})
+
+  defp maybe_create_access_token(
+         {:ok,
+          %{resource_owner: resource_owner, application: application, scopes: scopes} = grant},
+         token_params,
+         config
+       ) do
+    token_params =
+      grant
+      |> Map.drop([:expires_in])
+      |> Map.take(Config.access_token(config).required_fields())
+      |> Map.merge(token_params)
+      |> Map.merge(%{scopes: scopes, application: application})
 
     resource_owner
     |> AccessTokens.get_token_for(application, scopes, config)

--- a/lib/ex_oauth2_provider/oauth2/token/strategy/refresh_token.ex
+++ b/lib/ex_oauth2_provider/oauth2/token/strategy/refresh_token.ex
@@ -83,8 +83,8 @@ defmodule ExOauth2Provider.Token.RefreshToken do
   defp token_params(%{scopes: scopes, application: application} = refresh_token, config) do
     params =
       refresh_token
-      |> Map.drop([:expires_in])
-      |> Map.take(Config.access_token(config).required_fields())
+      |> Map.drop([:expires_in, :scopes])
+      |> Map.take(Config.access_token(config).allowed_fields())
       |> Map.merge(%{scopes: scopes, application: application, use_refresh_token: true})
 
     case Config.refresh_token_revoked_on_use?(config) do

--- a/test/support/lib/dummy/oauth_access_grants/oauth_access_grant.ex
+++ b/test/support/lib/dummy/oauth_access_grants/oauth_access_grant.ex
@@ -13,4 +13,19 @@ defmodule Dummy.OauthAccessGrants.OauthAccessGrant do
     access_grant_fields()
     timestamps()
   end
+
+  @impl ExOauth2Provider.Changeset
+  def allowed_fields do
+    access_grant_allowed_fields()
+  end
+
+  @impl ExOauth2Provider.Changeset
+  def required_fields do
+    access_grant_required_fields()
+  end
+
+  @impl ExOauth2Provider.Changeset
+  def request_fields do
+    access_grant_request_fields()
+  end
 end

--- a/test/support/lib/dummy/oauth_access_tokens/oauth_access_token.ex
+++ b/test/support/lib/dummy/oauth_access_tokens/oauth_access_token.ex
@@ -13,4 +13,19 @@ defmodule Dummy.OauthAccessTokens.OauthAccessToken do
     access_token_fields()
     timestamps()
   end
+
+  @impl ExOauth2Provider.Changeset
+  def allowed_fields do
+    access_token_allowed_fields()
+  end
+
+  @impl ExOauth2Provider.Changeset
+  def required_fields do
+    access_token_required_fields()
+  end
+
+  @impl ExOauth2Provider.Changeset
+  def request_fields do
+    access_token_request_fields()
+  end
 end


### PR DESCRIPTION
Allow the user to add additional fields to the schemas for grants and tokens. These fields can then be passed as params to existing functions are will be stored/retrieved from the database with the rest of the model.