### PR TITLE
added application preload to get_by_token

### DIFF
--- a/lib/ex_oauth2_provider/access_tokens/access_tokens.ex
+++ b/lib/ex_oauth2_provider/access_tokens/access_tokens.ex
@@ -29,9 +29,12 @@ defmodule ExOauth2Provider.AccessTokens do
   """
   @spec get_by_token(binary(), keyword()) :: AccessToken.t() | nil
   def get_by_token(token, config \\ []) do
+
     config
-    |> Config.access_token()
-    |> Config.repo(config).get_by(token: token)
+      |> Config.access_token()
+      |> Config.repo(config).get_by(token: token)
+      |> Config.repo(config).preload(:application)
+
   end
 
   @doc """


### PR DESCRIPTION
I noticed the application is not preloaded when the get_token function is called in ExOauth2Provider.AccessTokens. 

Found this out when I tried to use the 'client_crendentials' strategy. Apparently I needed access to the client application making the request to implement some business logic required by my app.

I hope this PR helps.