### PR TITLE
Update typespec for the cases when owner is nil

### DIFF
--- a/lib/ex_oauth2_provider/applications/applications.ex
+++ b/lib/ex_oauth2_provider/applications/applications.ex
@@ -150,8 +150,11 @@ defmodule ExOauth2Provider.Applications do
       iex> create_application(user, %{name: ""}, otp_app: :my_app)
       {:error, %Ecto.Changeset{}}
 
+      iex> create_application(nil, %{name: "App", redirect_uri: "http://example.com"}, otp_app: :my_app)
+      {:ok, %OauthApplication{}}
+
   """
-  @spec create_application(Schema.t(), map(), keyword()) :: {:ok, Application.t()} | {:error, Changeset.t()}
+  @spec create_application(Schema.t() | nil, map(), keyword()) :: {:ok, Application.t()} | {:error, Changeset.t()}
   def create_application(owner, attrs \\ %{}, config \\ []) do
     config
     |> Config.application()


### PR DESCRIPTION
In our server to server auth use case, there is no owner, so it will be nil. The code already supports this, but we get dialyzer warning when we pass owner as nil.