### PR TITLE
Fix using module.function deprecation warning.

### DIFF
--- a/lib/ex_oauth2_provider/mixin/expirable.ex
+++ b/lib/ex_oauth2_provider/mixin/expirable.ex
@@ -42,7 +42,7 @@ defmodule ExOauth2Provider.Mixin.Expirable do
   def is_expired?(%{expires_in: nil, inserted_at: _}), do: false
   def is_expired?(%struct{expires_in: expires_in, inserted_at: inserted_at}) do
     now  = SchemaHelpers.__timestamp_for__(struct, :inserted_at)
-    type = now.__struct__()
+    type = now.__struct__
 
     inserted_at
     |> type.add(expires_in, :second)


### PR DESCRIPTION
Hello there, how is it going?

First of all, thanks for the great library.

While bumping our project to elixir `1.17` we got the following deprecation warning:
```elixir
warning: using module.function() notation (with parentheses) to fetch map field :__struct__ is deprecated, you must remove the parentheses: map.field
  (ex_oauth2_provider 0.5.7) lib/ex_oauth2_provider/mixin/expirable.ex:45: ExOauth2Provider.Mixin.Expirable.is_expired?/1
  (ex_oauth2_provider 0.5.7) lib/ex_oauth2_provider/access_tokens/access_tokens.ex:234: ExOauth2Provider.AccessTokens.is_accessible?/1
  (ex_oauth2_provider 0.5.7) lib/ex_oauth2_provider.ex:86: ExOauth2Provider.validate_access_token/1
  (ex_oauth2_provider 0.5.7) lib/ex_oauth2_provider.ex:58: ExOauth2Provider.authenticate_token/2
  (ex_oauth2_provider 0.5.7) lib/ex_oauth2_provider/plug/verify_header.ex:78: ExOauth2Provider.Plug.VerifyHeader.verify_token/4
  ```
  
  This takes care of it.
  
  Let me know if you see any issues.

Cheers.